### PR TITLE
Set OCCA_CXX="g++" as default in makenrs

### DIFF
--- a/makenrs
+++ b/makenrs
@@ -12,7 +12,7 @@
 : ${NEKRS_CXXFLAGS:="-g -O2"}
 : ${NEKRS_DEBUG:=0}
 
-: ${OCCA_CXX:="gcc"}
+: ${OCCA_CXX:="g++"}
 : ${OCCA_CXXFLAGS:="-O2 -ftree-vectorize -funroll-loops -march=native -mtune=native"}
 
 ###############################################################################


### PR DESCRIPTION
When I used `OCCA_CXX="gcc"` on my system, the UDF compilation failed because it needed to link against some C++ runtime libs.  Using `OCCA_CXX="g++"` solved the problem, and it would probably be a good default.