### PR TITLE
Flags set correctly in nekrs.conf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,19 +101,7 @@ set (CMAKE_CXX_STANDARD 14)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE on)
 
-# For CMake targets, CMAKE_<LANG>_FLAGS and CMAKE_<LANG>_FLAGS_<CONFIG> are
-# both included automatically, based on the current <CONFIG>.  However, for
-# external projects, we need to explicitly include both sets of flags
-
-function(set_external_flags lang)
-  string(TOUPPER "${CMAKE_BUILD_TYPE}" mode)
-  set(EXTERNAL_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} ${CMAKE_${lang}_FLAGS_${mode}}"
-          PARENT_SCOPE)
-endfunction()
-
-set_external_flags("C")
-set_external_flags("CXX")
-set_external_flags("Fortran")
+add_definitions(-DUSE_OCCA_MEM_BYTE_ALIGN=${USE_OCCA_MEM_BYTE_ALIGN})
 
 find_package(OpenMP)
 if (OPENMP_FOUND)
@@ -121,6 +109,26 @@ if (OPENMP_FOUND)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
 endif()
+
+# For CMake targets, CMAKE_<LANG>_FLAGS, CMAKE_<LANG>_FLAGS_<CONFIG>, and
+# COMPILE_DEFINITIONS are included automatically, based on the current <CONFIG>.
+# For # external projects, we explicitly collect them
+function(set_external_flags lang)
+  string(TOUPPER "${CMAKE_BUILD_TYPE}" mode)
+  set(ext_flags "${CMAKE_${lang}_FLAGS} ${CMAKE_${lang}_FLAGS_${mode}}")
+
+  get_directory_property(compile_defs
+          DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" COMPILE_DEFINITIONS )
+  foreach(def "${compile_defs}")
+    set(ext_flags "${ext_flags} -D${def}")
+  endforeach()
+
+  set(EXTERNAL_${lang}_FLAGS "${ext_flags}" PARENT_SCOPE)
+endfunction()
+
+set_external_flags("C")
+set_external_flags("CXX")
+set_external_flags("Fortran")
 
 ###############################################################################
 # Generate nekrs.conf                                                       #
@@ -160,8 +168,6 @@ include(config/blaslapack.cmake)
 ###############################################################################
 # Build NekRS
 ###############################################################################
-
-add_definitions(-DUSE_OCCA_MEM_BYTE_ALIGN=${USE_OCCA_MEM_BYTE_ALIGN})
 
 set(SRC 
     src/nekrs.cpp

--- a/makenrs
+++ b/makenrs
@@ -9,8 +9,7 @@
 : ${NEKRS_CC:="mpicc"}
 : ${NEKRS_CXX:="mpic++"}
 : ${NEKRS_FC:="mpif77"}
-: ${NEKRS_CXXFLAGS:="-g -O2"}
-: ${NEKRS_DEBUG:=0}
+: ${NEKRS_CXXFLAGS:=""}
 
 : ${OCCA_CXX:="g++"}
 : ${OCCA_CXXFLAGS:="-O2 -ftree-vectorize -funroll-loops -march=native -mtune=native"}
@@ -163,11 +162,6 @@ if [ "${NEKRS_DIR}" =  "${NEKRS_INSTALL_DIR}" ]; then
   ${NEKRS_EXIT_CMD} 1
 fi
 
-NEKRS_BUILD_TYPE=RelWithDebInfo
-if [ ${NEKRS_DEBUG} -ne 0 ]; then
-  NEKRS_BUILD_TYPE=Debug
-fi
-
 # =======================
 # Run CMake
 # =======================
@@ -177,7 +171,7 @@ mkdir -p "${NEKRS_BUILD_DIR}" > /dev/null 2>&1
 cd "${NEKRS_BUILD_DIR}"
 # ENABLE_CUDA, ENABLE_OPENCL, etc., are used by OCCA's CMakeLists
 cmake -Wno-dev \
-      -DCMAKE_BUILD_TYPE="${NEKRS_BUILD_TYPE}" \
+      -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
       -DCMAKE_Fortran_COMPILER="${NEKRS_FC}" \
       -DCMAKE_C_COMPILER="${NEKRS_CC}" \
       -DCMAKE_CXX_COMPILER="${NEKRS_CXX}" \


### PR DESCRIPTION
Now correctly sets `CFLAGS`, `CXXFLAGS`, and `FFLAGS` in `nekrs.conf`.  For example:

```
[GENERAL]

CXX = /Users/ronald/install/openmpi-4.0-homebrew-gnu-9/bin/mpic++
CC = /Users/ronald/install/openmpi-4.0-homebrew-gnu-9/bin/mpicc
FC = /Users/ronald/install/openmpi-4.0-homebrew-gnu-9/bin/mpif77
CXXFLAGS =  -fopenmp -O2 -g -DNDEBUG -DUSE_OCCA_MEM_BYTE_ALIGN=64
CFLAGS =  -fopenmp -O2 -g -DNDEBUG -DUSE_OCCA_MEM_BYTE_ALIGN=64
FFLAGS =  -O2 -g -DNDEBUG -DUSE_OCCA_MEM_BYTE_ALIGN=64

NEK5000_PPLIST = PARRSB DPROCMAP
LIBP_DEFINES = -DUSE_NULL_PROJECTION=1
OCCA_CXX = g++
OCCA_CXXFLAGS = -O2 -ftree-vectorize -funroll-loops -march=native -mtune=native
```