### PR TITLE
Fixed OCCA build from nekrs tarball

### DIFF
--- a/config/occa.cmake
+++ b/config/occa.cmake
@@ -15,4 +15,4 @@ else()
   set(OCCA_SOURCE_DIR ${occa_content_SOURCE_DIR})
 endif()
 
-add_subdirectory(${OCCA_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/${occa_content_BINARY_DIR})
+add_subdirectory(${OCCA_SOURCE_DIR} ${occa_content_BINARY_DIR})


### PR DESCRIPTION
This fixes the following error message when building from a tarball:
```
-- Using OCCA source in nekRS-v20.1/3rd_party/occa
CMake Error at config/occa.cmake:18 (add_subdirectory):
  The binary directory

    nekRS-v20.1/build

  is already used to build a source directory.  It cannot be used to build
  source directory

    nekRS-v20.1/3rd_party/occa

  Specify a unique binary directory name.
Call Stack (most recent call first):
  CMakeLists.txt:146 (include)
```
