### PR TITLE
Make dimensions of interpRaise clearer to understand.

### DIFF
--- a/src/mesh/meshLoadReferenceNodesHex3D.cpp
+++ b/src/mesh/meshLoadReferenceNodesHex3D.cpp
@@ -59,7 +59,7 @@ void meshLoadReferenceNodesHex3D(mesh3D* mesh, int N, int cubN)
   mesh->DW = (dfloat*) malloc(mesh->Nq * mesh->Nq * sizeof(dfloat));
   DWmatrix1D(mesh->N, mesh->D, mesh->DW);
 
-  mesh->interpRaise = (dfloat* ) calloc(mesh->Nq * (mesh->Nq + 1),sizeof(dfloat));
+  mesh->interpRaise = (dfloat* ) calloc((mesh->Nq + 1) * mesh->Nq,sizeof(dfloat));
   mesh->interpLower = (dfloat* ) calloc((mesh->Nq - 1) * (mesh->Nq),sizeof(dfloat));
   DegreeRaiseMatrix1D(mesh->N, mesh->N + 1, mesh->interpRaise);
   DegreeRaiseMatrix1D(mesh->N - 1, mesh->N, mesh->interpLower);


### PR DESCRIPTION
All morning I was trying to understand the `DegreeRaiseMatrix1D` function, because I was under the impression based on the code convention that `mesh->interpRaise` was size `mesh->Nq` by `mesh->Nq+1`. This is based on the convention pretty much everywhere else that `calloc` is called with the size ordered as #rows * #cols * sizeof(entry).

Of course from a memory storage point of view all the data is stored contiguously, but I could not for the life of me understand what `interpRaise` really meant until I realized that the dimensions were actually `mesh->Nq+1` by `mesh->Nq` (i.e. `V_out * V_in^{-1}` for interpolating to a finer mesh, where `V` are the Vandermonde matrices for the transformation).

This should have zero effect on code behavior, but if were written this way would have saved me a lot of head-scratching :)