### PR TITLE
Remove redundant check for whether some UDF function pointers exist.

### DIFF
--- a/src/core/insSetup.cpp
+++ b/src/core/insSetup.cpp
@@ -257,11 +257,9 @@ ins_t* insSetup(MPI_Comm comm, occa::device device, setupAide &options, int buil
   kernelInfo["defines/" "p_cubNblockS"] = cubNblockS;
 
   // jit compile udf kernels
-  if (udf.loadKernels) {
-    if (mesh->rank == 0) cout << "loading udf kernels ... ";
-    udf.loadKernels(ins);
-    if (mesh->rank == 0) cout << "done" << endl;
-  }
+  if (mesh->rank == 0) cout << "loading udf kernels ... ";
+  udf.loadKernels(ins);
+  if (mesh->rank == 0) cout << "done" << endl;
 
   ins->linAlg = new linAlg_t(mesh->device, ins->kernelInfo, mesh->comm);
 

--- a/src/nekrs.cpp
+++ b/src/nekrs.cpp
@@ -103,7 +103,7 @@ void setup(MPI_Comm comm_in, int buildOnly, int sizeTarget,
   int readRestartFile;
   options.getArgs("RESTART FROM FILE", readRestartFile);
   if(readRestartFile) nek_copyRestart();
-  if(udf.setup) udf.setup(ins);
+  udf.setup(ins);
 
 /*
   if(options.compareArgs("VARIABLEPROPERTIES", "TRUE")) {
@@ -135,7 +135,7 @@ void setup(MPI_Comm comm_in, int buildOnly, int sizeTarget,
     if(ins->Nscalar) ins->cds->o_prop.copyTo(ins->cds->prop);
   }
 
-  if(udf.executeStep) udf.executeStep(ins, ins->startTime, 0);
+  udf.executeStep(ins, ins->startTime, 0);
   nek_ocopyFrom(ins->startTime, 0);
 
   timer::toc("setup");
@@ -170,7 +170,7 @@ void udfExecuteStep(double time, int tstep, int isOutputStep)
     ins->isOutputStep = 1;
   }
 
-  if (udf.executeStep) udf.executeStep(ins, time, tstep);
+  udf.executeStep(ins, time, tstep);
 
   nek_ifoutfld(0);
   ins->isOutputStep = 0;


### PR DESCRIPTION
In `udfLoad`, we require `UDF_Setup`, `UDF_LoadKernels`, and `UDF_ExecuteStep` to be available by passing in `true` for the error checking flag. So, we are guaranteed that the `udf.setup`, `udf.loadKernels`, and `udf.executeStep` function pointers are not NULL, so we can remove redundant checks for these three pointers.

This change makes the code more understandable and transparent as to what the user _must_ have in their `.udf` file.