### PR TITLE
Make timestep end criterion easier to read.

### DIFF
--- a/src/lib/nekrs.cpp
+++ b/src/lib/nekrs.cpp
@@ -201,7 +201,7 @@ const int lastStep(double time, int tstep, double elapsedTime)
      const double eps = 1e-12;
      nrs->lastStep = fabs((time+nrs->dt[0]) - endTime()) < eps || (time+nrs->dt[0]) > endTime();
   } else {
-    nrs->lastStep = (tstep+1 > numSteps());
+    nrs->lastStep = tstep == numSteps();
   }
 
   return nrs->lastStep;


### PR DESCRIPTION
Readability change! Kind of confusing the way it is written right now, IMO.