### PR TITLE
Wrap output writing in function.

### DIFF
--- a/src/lib/nekrs.cpp
+++ b/src/lib/nekrs.cpp
@@ -217,7 +217,21 @@ void* nrsPtr(void)
   return nrs;
 }
 
+int isOutputStep(int tStep, double time, double outputTime, int lastStep)
+{
+  int outputStep = 0;
 
+  if (writeControlRunTime()) {
+    outputStep = (time >= outputTime);
+  } else {
+    if (writeInterval() > 0) outputStep = (tStep%(int)writeInterval() == 0);
+  }
+  if (writeInterval() == 0) outputStep = 0;
+  if (lastStep) outputStep = 1;
+  if (writeInterval() < 0) outputStep = 0;
+
+  return outputStep;
+}
 
 void printRuntimeStatistics()
 {

--- a/src/lib/nekrs.hpp
+++ b/src/lib/nekrs.hpp
@@ -23,6 +23,7 @@ const double endTime(void);
 const int numSteps(void);
 const int lastStep(double time, int tstep, double elapsedTime);
 const int writeControlRunTime(void);
+int isOutputStep(int tStep, double time, double outputTime, int lastStep);
 
 void* nrsPtr(void);
 void* nekPtr(const char* id);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,15 +166,7 @@ int main(int argc, char** argv)
     nekrs::runStep(time, dt, tStep);
     time += dt;
 
-    int outputStep = 0;
-    if (writeControlRunTime) { 
-      outputStep = (time >= outputTime);
-    } else {
-      if (nekrs::writeInterval() > 0) outputStep = (tStep%(int)nekrs::writeInterval() == 0);
-    }
-    if (nekrs::writeInterval() == 0) outputStep = 0;
-    if (lastStep) outputStep = 1;
-    if (nekrs::writeInterval() < 0) outputStep = 0;
+    int outputStep = nekrs::isOutputStep(tStep, time, outputTime, lastStep);
 
     nekrs::udfExecuteStep(time, tStep, outputStep);
 


### PR DESCRIPTION
This PR moves the capability of figuring out whether the current time step is an output step into a function. This ensures that other codes that rely on nekRS don't break every time this logic changes (as they just did last week).

To elaborate:

1. Other functions related to output are already placed into the `nekrs` lib, such as `writeControlRunTime()` and `lastStep()`. It makes sense from an encapsulation perspective to also put the capability of figuring out whether it is an output step in the same place. You also already use the `nekrs` namespace in `main.cpp`, so it's not like this would expose any new parts of the code base to one another.

2. Any code that wraps nekRS, such as Cardinal, needs to know if each time step is an output step. If these 10 lines aren't wrapped into a function that Cardinal can call, we need to copy and paste these 10 lines into our code base. This is messy and difficult to keep up to date as you change nekRS. For instance, in the last big update, this function changed considerably. I would guess that this change could also benefit the output file writing that @RonRahaman does in Enrico.

3. Moving this capability into a function in no way changes the operation of nekRS.