### PR TITLE
Eliminate redundancy bewteen SOLVER and TEMPERATURE parameters.

### DIFF
--- a/src/core/parReader.cpp
+++ b/src/core/parReader.cpp
@@ -547,12 +547,13 @@ setupAide parRead(std::string &setupFile, MPI_Comm comm)
     nscal++;
     isStart++;
 
+    options.setArgs("SCALAR00 IS TEMPERATURE", "TRUE");
+
     string solver;
     ini.extract("temperature", "solver", solver);
     if(solver == "none") {
       options.setArgs("SCALAR00 SOLVER", "NONE");
     } else {
-      options.setArgs("TEMPERATURE", "TRUE");
       options.setArgs("SCALAR INITIAL GUESS DEFAULT","PREVIOUS STEP");
       options.setArgs("SCALAR00 PRECONDITIONER", "JACOBI");
       bool t_rproj;

--- a/src/core/setup.cpp
+++ b/src/core/setup.cpp
@@ -77,7 +77,7 @@ nrs_t* nrsSetup(MPI_Comm comm, occa::device device, setupAide &options, int buil
   }
   mesh_t* mesh = nrs->mesh;
 
-  if (nrs->cht && !nrs->options.compareArgs("TEMPERATURE", "TRUE")) {
+  if (nrs->cht && !nrs->options.compareArgs("SCALAR00 IS TEMPERATURE", "TRUE")) {
     if (mesh->rank == 0) cout << "Conjugate heat transfer requires solving for temperature!\n"; 
     EXIT(1);
   } 

--- a/src/plugins/lowMach.cpp
+++ b/src/plugins/lowMach.cpp
@@ -12,7 +12,7 @@ void lowMach::setup(nrs_t* nrs)
 {
   mesh_t* mesh = nrs->mesh;
   int err = 1;
-  if(nrs->options.compareArgs("TEMPERATURE", "TRUE")) err = 0;
+  if(nrs->options.compareArgs("SCALAR00 IS TEMPERATURE", "TRUE")) err = 0;
   if(err) {
     if(mesh->rank == 0) cout << "lowMach requires solving for temperature!\n";
     ABORT(1);


### PR DESCRIPTION
The `TEMPERATURE` and `SCALAR00 SOLVER` parameters were erroneously redundant. This fixes that and allows you to tell the difference between temperature not existing in the input file vs. having its solver turned off.