### PR TITLE
Error reading nelgt and nelgv from re2

### DIFF
--- a/src/nekInterface/nekInterfaceAdapter.cpp
+++ b/src/nekInterface/nekInterfaceAdapter.cpp
@@ -466,7 +466,7 @@ int buildNekInterface(const char* casename, int ldimt, int N, int np)
   char ver[10];
   int ndim;
   hlong nelgv, nelgt;
-  sscanf(buf, "%5s %9d %1d %9d", ver, &nelgt, &ndim, &nelgv);
+  sscanf(buf, "%5s %9lld %1d %9lld", ver, &nelgt, &ndim, &nelgv);
   int lelt = (int)(nelgt/np) + 3;
   if(lelt > nelgt) lelt = (int)nelgt;
   mkSIZE(N + 1, 1, lelt, nelgt, ndim, np, ldimt);


### PR DESCRIPTION
When `nelgt` and `nelgv` are parsed from the re2 file, there is a type mismatch.  They are declared as `long long int`
```
//host index data type
#if 0
#define hlong int
#define MPI_HLONG MPI_INT
#define hlongFormat "%d"
#define hlongString "int"
#else
#define hlong long long int
#define MPI_HLONG MPI_LONG_LONG_INT
#define hlongFormat "%lld"
#define hlongString "long long int"
#endif
```
However, the `sscanf` function read them as `int`.  This led to some data corruption, which was apparent in the generated SIZE file.  

This PR fixes the issue by reading them as `long long int`