### PR TITLE
Replaced shell rm and mkdir with C versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ include(config/blaslapack.cmake)
 set(SRC 
     src/lib/nekrs.cpp
     src/io/writeFld.cpp
+    src/core/utils/filesystem.cpp
     src/core/utils/mysort.cpp
     src/core/utils/parallelSort.cpp
     src/core/utils/occaHelpers.cpp

--- a/src/core/utils/filesystem.cpp
+++ b/src/core/utils/filesystem.cpp
@@ -1,0 +1,99 @@
+#include "filesystem.hpp"
+
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 500 // Get nftw() declarations
+#endif
+
+#include <iostream>
+#include <sstream>
+#include <stdio.h>
+#include <cstring>
+#include <ftw.h>
+#include <sys/stat.h>
+#include <limits.h>
+#include <libgen.h>
+
+static int rm_from_nftw(const char* pathname,
+                        const struct stat* sbuf,
+                        int type,
+                        struct FTW* ftwb)
+{
+  switch (type) {
+  case FTW_F:
+  case FTW_DP:
+    if (remove(pathname) != 0) {
+      std::cerr << "ERROR: could not remove " << pathname << std::endl;
+      return -1;
+    }
+    break;
+  default:
+    break;
+  }
+  return 0;
+}
+
+std::deque<std::string> fsys_path_split(const std::string& path)
+{
+  std::deque<std::string> result;
+  char p[PATH_MAX];
+  strcpy(p, path.c_str());
+
+  do {
+    auto dir = dirname(p);
+    auto base = basename(p);
+    result.push_front(base);
+    strcpy(p, dir);
+  } while (strcmp(p, ".") != 0 && strcmp(p, "/") != 0);
+
+  if (strcmp(p, "/") == 0) {
+    result.push_front("/");
+  }
+
+  return result;
+}
+
+int fsys_mkdir(const std::string& path, bool recurse)
+{
+  std::deque<std::string> dirs;
+  if (recurse) {
+    dirs = fsys_path_split(path);
+  } else {
+    dirs.push_back(path);
+  }
+
+  std::string next_dir;
+  for (const auto& d : dirs) {
+    next_dir = next_dir + "/" + d;
+    struct stat sb;
+    if (stat(next_dir.c_str(), &sb) == 0) {
+      if (!S_ISDIR(sb.st_mode)) {
+        std::cerr << "ERROR: cannot create directory '" << next_dir
+                  << "': not a directory" << std::endl;
+        return -1;
+      }
+    } else if (mkdir(next_dir.c_str(), S_IRWXU | S_IRWXG) != 0) {
+      std::cerr << "ERROR: failed to create directory `" << next_dir << "'" << std::endl;
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+int fsys_rm(const std::string &path, bool followSymlinks)
+{
+  int flags = FTW_DEPTH;
+  if (!followSymlinks) {
+    flags |= FTW_PHYS;
+  }
+
+  struct stat s;
+  if (stat(path.c_str(), &s) == 0) {
+    if (nftw(path.c_str(), rm_from_nftw, 10, flags) != 0) {
+      std::cerr << "ERROR: could not recursively remove " << path << std::endl;
+      return -1;
+    }
+  }
+  return 0;
+}
+

--- a/src/core/utils/filesystem.hpp
+++ b/src/core/utils/filesystem.hpp
@@ -1,0 +1,22 @@
+#ifndef NEKRS_FILESYSTEM_H
+#define NEKRS_FILESYSTEM_H
+
+#include <string>
+#include <deque>
+
+// Split a given path into components
+std::deque<std::string> fsys_path_split(const std::string& path);
+
+// Make a directory at a given path
+int fsys_mkdir(const std::string& path, bool recurse = true);
+
+// Removes a file or directory.  
+// * Always recursive and does not raise errors if a given file/dir 
+//   does not exist (like rm -rf)
+// * By default, will not follow symlinked dirs and will just 
+//   remove the the symlinks themselves.  Set `followSymlinks` to 
+//   `true` to follow symlinked dirs to the destination path and remove 
+//   the contents at the destination.  
+int fsys_rm(const std::string &path, bool followSymlinks = false);
+
+#endif 


### PR DESCRIPTION
This replaces the use of the shell utils `rm` and `mkdir` in `udfBuild` with functions from the UNIX C API.  It fixes issues we were seeing in our multiphysics app with large problems on Summit and other clusters.  

The UNIX API functions are encapsulated in the functions `fsys_rm` and `fsys_mkdir` in `core/utils/filesystem.cpp`.  They provide the functionality of `rm -rf` and `mkdir -p`.  

The following are not addressed in this PR:
* The proposed `--no-jit` option, which would skip JIT completely.  It's just taking some time to get it exactly right, and I wanted to provide the fix in this PR first.
* The usage of the shell `cp` util in nekInterface.  I'm not prioritizing this highly because:
  - It's quite a lot of code to implement a completely robust `cp -r` with just the UNIX C API, unlike `rm` and `mkdir` which were straightforward.  
  - The usage of the shell `cp` util is not a source of errors in our app yet.  
  - The implemented `--no-jit` option will probably obviate the need to address this.  