### PR TITLE
Adding src/lib to header path for libnekrs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ target_include_directories(nekrs-lib
   PUBLIC 
   src/core
   src/core/utils
+  src/lib
   src/io
   src/udf
   src/linAlg


### PR DESCRIPTION
This adds the directory `src/lib` to the public header search path for NekRS.  Without it, CMake projects that included NekRS weren't able to link to libnekrs correctly.