### PR TITLE
(#305)(Hotfix) Use g++, rather than xlc, for OCCA kernel launcher compilation.

### DIFF
--- a/scripts/nrsqsub_summit
+++ b/scripts/nrsqsub_summit
@@ -22,9 +22,15 @@ export NEKRS_HOME
 export OCCA_CACHE_DIR
 export NEKRS_HYPRE_NUM_THREADS=1
 export NEKRS_GPU_MPI=1
-export OCCA_CXX="$XL_HOME/bin/xlc" 
-export OCCA_CXXFLAGS="-O3 -qarch=pwr9 -qhot -DUSE_OCCA_MEM_BYTE_ALIGN=64" 
-export OCCA_LDFLAGS="$XL_HOME/lib/libibmc++.a"
+
+# XLC compiler
+#export OCCA_CXX="$XL_HOME/bin/xlc" 
+#export OCCA_CXXFLAGS="-O3 -qarch=pwr9 -qhot -DUSE_OCCA_MEM_BYTE_ALIGN=64" 
+#export OCCA_LDFLAGS="$XL_HOME/lib/libibmc++.a"
+
+# g++ compiler
+export OCCA_CXX="g++" 
+export OCCA_CXXFLAGS="-O2 -DUSE_OCCA_MEM_BYTE_ALIGN=64" 
 
 #export OMPI_LD_PRELOAD_POSTPEND=$OLCF_SPECTRUM_MPI_ROOT/lib/libmpitrace.so
 


### PR DESCRIPTION
This allows the current nekRS/master to run on Summit.

I've tested the following cases on gcc/7.4.0, cuda/10.2.89:
- [x]  ethier, single node Summit
- [x] turbPipePeriodic, single node Summit
- [x] pb146, single node Summit
- [x] pb146, two nodes Summit
- [x] kershaw, single node Summit

Note this is not a true fix for (#305). However, this should allow users to run on Summit while I further investigate this issue.

I don't have access to lassen, so I am unsure if this issue is also there.