### PR TITLE
(#305) Remove occa::primitive::source

### DIFF
--- a/3rd_party/occa/include/occa/types/primitive.hpp
+++ b/3rd_party/occa/include/occa/types/primitive.hpp
@@ -56,7 +56,6 @@ namespace occa {
   class primitive {
   public:
     int type;
-    std::string source;
 
     union {
       bool bool_;
@@ -83,14 +82,13 @@ namespace occa {
     }
 
     inline primitive(const primitive &p) :
-        type(p.type),
-        source(p.source) {
+        type(p.type)
+    {
       value.ptr = p.value.ptr;
     }
 
     inline primitive& operator = (const primitive &p) {
       type = p.type;
-      source = p.source;
       value.ptr = p.value.ptr;
       return *this;
     }

--- a/3rd_party/occa/src/types/primitive.cpp
+++ b/3rd_party/occa/src/types/primitive.cpp
@@ -31,14 +31,12 @@ namespace occa {
 
     if (strncmp(c, "true", 4) == 0) {
       p = true;
-      p.source = "true";
 
       c += 4;
       return p;
     }
     if (strncmp(c, "false", 5) == 0) {
       p = false;
-      p.source = "false";
 
       c += 5;
       return p;
@@ -90,7 +88,6 @@ namespace occa {
 
     if (!loadedFormattedValue && !digits) {
       c = c0;
-      p.source = std::string(c0, c - c0);
       return p;
     }
 
@@ -161,7 +158,6 @@ namespace occa {
       }
     }
 
-    p.source = std::string(c0, c - c0);
     return p;
   }
 
@@ -226,10 +222,6 @@ namespace occa {
   }
 
   std::string primitive::toString() const {
-    if (source.size()) {
-      return source;
-    }
-
     std::string str;
     switch (type) {
       case primitiveType::bool_   : str = (value.bool_ ? "true" : "false");         break;


### PR DESCRIPTION
This fixes (#305), although I'm sure we'll need to take a closer look at OCCA later.

Closes (#305).

Cases tested:
- [x] pb146 on two nodes Summit
