### PR TITLE
[#305][Hotfix] Don't cross-compile OCCA kernel launchers unless in serial mode.

### DIFF
--- a/scripts/nrsqsub_lassen
+++ b/scripts/nrsqsub_lassen
@@ -21,9 +21,11 @@ export NEKRS_HOME
 export OCCA_CACHE_DIR
 export NEKRS_HYPRE_NUM_THREADS=1
 export NEKRS_GPU_MPI=1
-export OCCA_CXX="$XL_HOME/bin/xlc" 
-export OCCA_CXXFLAGS="-O3 -qarch=pwr9 -qhot -DUSE_OCCA_MEM_BYTE_ALIGN=64" 
-export OCCA_LDFLAGS="$XL_HOME/lib/libibmc++.a"
+if [ $CPUONLY -eq 1 ]; then
+  export OCCA_CXX="$XL_HOME/bin/xlc++" 
+  export OCCA_CXXFLAGS="-O3 -qarch=pwr9 -qhot -DUSE_OCCA_MEM_BYTE_ALIGN=64" 
+  export OCCA_LDFLAGS="$XL_HOME/lib/libibmc++.a"
+fi
 
 export OMPI_MCA_io=romio321
 export ROMIO_HINTS="$(pwd)/.romio_hint"

--- a/scripts/nrsqsub_summit
+++ b/scripts/nrsqsub_summit
@@ -23,7 +23,7 @@ export OCCA_CACHE_DIR
 export NEKRS_HYPRE_NUM_THREADS=1
 export NEKRS_GPU_MPI=1
 if [ $CPUONLY -eq 1 ]; then
-  export OCCA_CXX="$XL_HOME/bin/xlc" 
+  export OCCA_CXX="$XL_HOME/bin/xlc_r" 
   export OCCA_CXXFLAGS="-O3 -qarch=pwr9 -qhot -DUSE_OCCA_MEM_BYTE_ALIGN=64" 
   export OCCA_LDFLAGS="$XL_HOME/lib/libibmc++.a"
 fi

--- a/scripts/nrsqsub_summit
+++ b/scripts/nrsqsub_summit
@@ -29,7 +29,7 @@ export OCCA_CACHE_DIR
 export NEKRS_HYPRE_NUM_THREADS=1
 export NEKRS_GPU_MPI=1
 if [ $CPUONLY -eq 1 ]; then
-  export OCCA_CXX="$XL_HOME/bin/xlc++_r" 
+  export OCCA_CXX="$XL_HOME/bin/xlc++" 
   export OCCA_CXXFLAGS="-O3 -qarch=pwr9 -qhot -DUSE_OCCA_MEM_BYTE_ALIGN=64" 
   export OCCA_LDFLAGS="$XL_HOME/lib/libibmc++.a"
 fi

--- a/scripts/nrsqsub_summit
+++ b/scripts/nrsqsub_summit
@@ -15,16 +15,18 @@ fi
 : ${NEKRS_HOME:="$HOME/.local/nekrs"}
 : ${OCCA_CACHE_DIR:="$PWD/.cache/occa"}
 NVME_HOME="/mnt/bb/$USER/"
-XL_HOME="/sw/summit/xl/16.1.1-3/xlC/16.1.1"
+XL_HOME="/sw/summit/xl/16.1.1-9/xlC/16.1.1"
 
 : ${CPUONLY:=0}
 export NEKRS_HOME
 export OCCA_CACHE_DIR
 export NEKRS_HYPRE_NUM_THREADS=1
 export NEKRS_GPU_MPI=1
-export OCCA_CXX="$XL_HOME/bin/xlc" 
-export OCCA_CXXFLAGS="-O3 -qarch=pwr9 -qhot -DUSE_OCCA_MEM_BYTE_ALIGN=64" 
-export OCCA_LDFLAGS="$XL_HOME/lib/libibmc++.a"
+if [ $CPUONLY -eq 1 ]; then
+  export OCCA_CXX="$XL_HOME/bin/xlc" 
+  export OCCA_CXXFLAGS="-O3 -qarch=pwr9 -qhot -DUSE_OCCA_MEM_BYTE_ALIGN=64" 
+  export OCCA_LDFLAGS="$XL_HOME/lib/libibmc++.a"
+fi
 
 #export OMPI_LD_PRELOAD_POSTPEND=$OLCF_SPECTRUM_MPI_ROOT/lib/libmpitrace.so
 

--- a/scripts/nrsqsub_summit
+++ b/scripts/nrsqsub_summit
@@ -23,7 +23,7 @@ export OCCA_CACHE_DIR
 export NEKRS_HYPRE_NUM_THREADS=1
 export NEKRS_GPU_MPI=1
 if [ $CPUONLY -eq 1 ]; then
-  export OCCA_CXX="$XL_HOME/bin/xlc_r" 
+  export OCCA_CXX="$XL_HOME/bin/xlc++_r" 
   export OCCA_CXXFLAGS="-O3 -qarch=pwr9 -qhot -DUSE_OCCA_MEM_BYTE_ALIGN=64" 
   export OCCA_LDFLAGS="$XL_HOME/lib/libibmc++.a"
 fi

--- a/scripts/nrsqsub_summit
+++ b/scripts/nrsqsub_summit
@@ -15,7 +15,13 @@ fi
 : ${NEKRS_HOME:="$HOME/.local/nekrs"}
 : ${OCCA_CACHE_DIR:="$PWD/.cache/occa"}
 NVME_HOME="/mnt/bb/$USER/"
-XL_HOME="/sw/summit/xl/16.1.1-9/xlC/16.1.1"
+
+# temporary load xl modules for OLCF_XLC_ROOT
+module load xl
+XL_HOME="$OLCF_XLC_ROOT"
+
+# reload previously used module
+module load gcc
 
 : ${CPUONLY:=0}
 export NEKRS_HOME


### PR DESCRIPTION
Avoid cross compiling the OCCA kernel launchers unless in serial mode.'

This closes #305 