### PR TITLE
Bugfix: Fix restarted GMRES code when using solution projection.

### DIFF
--- a/examples/ethier/ci.inc
+++ b/examples/ethier/ci.inc
@@ -57,6 +57,13 @@ void ciSetup(MPI_Comm comm, setupAide &options)
     options.setArgs("SUBCYCLING STEPS", string("1"));
     options.setArgs("MOVING MESH", string("TRUE"));
   }
+  if (ciMode == 7) {
+    options.setArgs("PRESSURE RESIDUAL PROJECTION", "TRUE");
+    options.setArgs("PRESSURE MAXIMUM ITERATIONS", "1000");
+    options.setArgs("PRESSURE PRECONDITIONER", "JACOBI");
+    options.setArgs("VELOCITY RESIDUAL PROJECTION", "TRUE");
+    options.setArgs("END TIME", string("0.012"));
+  }
 
   options.setArgs("TIME INTEGRATOR", "TOMBO3");
   options.setArgs("ADVECTION TYPE", "CONVECTIVE+CUBATURE");
@@ -123,7 +130,7 @@ void ciTestLinAlg(const int N)
 void ciTestErrors(nrs_t *nrs, dfloat time, int tstep)
 {
   const int rank = platform->comm.mpiRank;
-  if(tstep == 1){
+  if(tstep == 1 && ciMode != 7){
     int NiterP = nrs->pSolver->Niter;
     const int expectedNiterP = 6;
     const int pIterErr = abs(NiterP - expectedNiterP);
@@ -225,6 +232,15 @@ void ciTestErrors(nrs_t *nrs, dfloat time, int tstep)
              prErr = abs((err[1] - 2.89E-06)/err[1]);
              s01IterErr = abs(NiterS01 - 5);
              s02IterErr = abs(NiterS02 - 5);
+             break;
+    case 7 : velIterErr = abs(NiterU - 5);
+             s1Err = abs((err[2] - 2E-13)/err[2]);
+             s2Err = abs((err[3] - 2E-13)/err[3]);
+             pIterErr = abs(NiterP - 409);
+             vxErr = abs((err[0] - 1.4E-10)/err[0]);
+             prErr = abs((err[1] - 8.7E-9)/err[1]);
+             s01IterErr = abs(NiterS01 - 2);
+             s02IterErr = abs(NiterS02 - 2);
              break;
 
      }

--- a/src/elliptic/ellipticSolve.cpp
+++ b/src/elliptic/ellipticSolve.cpp
@@ -53,13 +53,6 @@ void ellipticSolve(elliptic_t* elliptic, occa::memory &o_r, occa::memory &o_x)
     if(platform->comm.mpiRank == 0) printf("RHS norm: %.15e\n", rhsNorm);
   }
 
-  if(options.compareArgs("KRYLOV SOLVER", "PGMRES")){
-    elliptic->o_rtmp.copyFrom(o_r, elliptic->Nfields * elliptic->Ntotal * sizeof(dfloat));
-    if(elliptic->allNeumann) ellipticZeroMean(elliptic, elliptic->o_rtmp);
-    oogs::startFinish(elliptic->o_rtmp, elliptic->Nfields, elliptic->Ntotal, ogsDfloat, ogsAdd, elliptic->oogs);
-    if(elliptic->Nmasked) mesh->maskKernel(elliptic->Nmasked, elliptic->o_maskIds, elliptic->o_rtmp);
-  }
-
   if(elliptic->var_coeff && options.compareArgs("PRECONDITIONER", "JACOBI"))
     ellipticUpdateJacobi(elliptic);
 

--- a/src/elliptic/linearSolver/PGMRES.cpp
+++ b/src/elliptic/linearSolver/PGMRES.cpp
@@ -140,9 +140,25 @@ int pgmres(elliptic_t* elliptic, occa::memory &o_r, occa::memory &o_x,
 
   occa::memory& o_w = elliptic->o_p;
   occa::memory& o_b = elliptic->o_rtmp;
+  
 
   occa::memory& o_z = elliptic->o_z;
   occa::memory& o_Ax = elliptic->o_Ap;
+
+  // r = b - Ax =>
+  // r + Ax = b
+  ellipticOperator(elliptic, o_x, o_Ax, dfloatString);
+  platform->linAlg->axpbyzMany(
+    mesh->Nlocal,
+    elliptic->Nfields,
+    elliptic->Ntotal,
+    1.0,
+    o_r,
+    1.0,
+    o_Ax,
+    o_b
+  );
+
   deviceVector_t& o_V = elliptic->gmresData->o_V;
   deviceVector_t& o_Z = elliptic->gmresData->o_Z;
 


### PR DESCRIPTION
Previously, the rhs used to recompute the residual was incorrect
whenever solution projection was being used.
This caused cases to converge to the wrong pressure value
whenever GMRES had to restart.

This bug did not affect runs using PCG or where solution projection was not used.
The CI tests did not catch this, as all of the pressure solves converged
prior to needing to be restarted.