### PR TITLE
Allow scalar solves to be turned off.

### DIFF
--- a/src/core/setup.cpp
+++ b/src/core/setup.cpp
@@ -1095,6 +1095,7 @@ cds_t* cdsSetup(nrs_t* nrs, setupAide options, occa::properties& kernelInfoBC)
   bool avmEnabled = false;
   {
     for(int is = 0; is < cds->NSfields; is++) {
+      if(!cds->compute[is]) continue;
       if(!cds->options[is].compareArgs("FILTER STABILIZATION", "NONE")) scalarFilteringEnabled = true;
       if(cds->options[is].compareArgs("FILTER STABILIZATION", "AVM")) avmEnabled = true;
     }
@@ -1106,6 +1107,7 @@ cds_t* cdsSetup(nrs_t* nrs, setupAide options, occa::properties& kernelInfoBC)
     cds->o_filterMT = platform->device.malloc(cds->NSfields * Nmodes * Nmodes, sizeof(dfloat));
     for(int is = 0; is < cds->NSfields; is++)
     {
+      if(!cds->compute[is]) continue;
       if(cds->options[is].compareArgs("FILTER STABILIZATION", "NONE")) continue;
       int filterNc = -1;
       cds->options[is].getArgs("HPFRT MODES", filterNc);


### PR DESCRIPTION
In Cardinal, we have many tests that turn the scalar solves off (in order to check things like extraction of Nek's temperature and projection onto a MOOSE mesh, based on a known IC set in the .udf file). With the latest update, you get an error related to filter setup because there's not any actual check that the scalar solve is actually enabled:

```
ERROR: filterNc must be at least 1, but is set to -1
```

This PR fixes that. 

Can a test be added to NekRS that turns the scalar solves off? This is a common case in Cardinal's tests, but also applies to other users who might use a scalar to write mu_T, and then read it in for a temperature-only solve later on (or just more generally for cases where you might be adding turbulence later, but want to run a laminar case first). This isn't the first time that this same lack of test coverage has required a fix PR like this.