### PR TITLE
Shorten k tau test

### DIFF
--- a/examples/ktauChannel/channel.par
+++ b/examples/ktauChannel/channel.par
@@ -2,7 +2,7 @@
 polynomialOrder = 7
 #startFrom = "r.fld"+time=0
 stopAt = endTime
-endTime = 500
+endTime = 50
 dt = 2e-02
 timeStepper = tombo2
 


### PR DESCRIPTION
This PR shortens the `ktauChannel` test so that Cardinal can run it in a reasonable time on INL's testing system. Per the discussion on Slack, this should not have a significant influence on the converged solution but will enable a more uniform testing of NekRS via Cardinal.