### PR TITLE
Replace cout and endl with full namespace.

### DIFF
--- a/src/core/bcMap.cpp
+++ b/src/core/bcMap.cpp
@@ -74,7 +74,7 @@ static void v_setup(string field, std::vector<std::string> slist)
     if (key.compare("symz") == 0) key = "zerozvalue/zerogradient";
 
     if (vBcTextToID.find(key) == vBcTextToID.end()) {
-      cout << "Invalid bcType " << "\'" << key << "\'" << "!\n";
+      std::cout << "Invalid bcType " << "\'" << key << "\'" << "!\n";
       ABORT(1);
     }
 
@@ -84,7 +84,7 @@ static void v_setup(string field, std::vector<std::string> slist)
     }
     catch (const std::out_of_range& oor)
     {
-      cout << "Out of Range error: " << oor.what() << "!\n";
+      std::cout << "Out of Range error: " << oor.what() << "!\n";
       ABORT(1);
     }
   }
@@ -107,7 +107,7 @@ static void s_setup(string field, std::vector<std::string> slist)
     if (key.compare("o") == 0) key = "zerogradient";
 
     if (sBcTextToID.find(key) == sBcTextToID.end()) {
-      cout << "Invalid bcType " << "\'" << key << "\'" << "!\n";
+      std::cout << "Invalid bcType " << "\'" << key << "\'" << "!\n";
       ABORT(1);
     }
 
@@ -117,7 +117,7 @@ static void s_setup(string field, std::vector<std::string> slist)
     }
     catch (const std::out_of_range& oor)
     {
-      cout << "Out of Range error: " << oor.what() << "!\n";
+      std::cout << "Out of Range error: " << oor.what() << "!\n";
       ABORT(1);
     }
   }
@@ -188,7 +188,7 @@ int type(int bid, string field)
     if (bcID == 3) return NEUMANN;
   }
 
-  cout << __func__ << "(): Unexpected error occured!" << endl;
+  std::cout << __func__ << "(): Unexpected error occured!" << std::endl;
   ABORT(1);
   return 0;
 }
@@ -207,7 +207,7 @@ string text(int bid, string field)
     return sBcIDToText[bcID];
 
 
-  cout << __func__ << "(): Unexpected error occured!" << endl;
+  std::cout << __func__ << "(): Unexpected error occured!" << std::endl;
   ABORT(1);
   return 0;
 }
@@ -261,7 +261,7 @@ void setBcMap(string field, int* map, int nIDs)
   }
   catch (const std::out_of_range& oor)
   {
-    cout << "Out of Range error: " << oor.what() << "!\n";
+    std::cout << "Out of Range error: " << oor.what() << "!\n";
     ABORT(1);
   }
 }

--- a/src/core/configReader.cpp
+++ b/src/core/configReader.cpp
@@ -24,7 +24,7 @@ void configRead(MPI_Comm comm)
   char* nekrs_home = getenv("NEKRS_HOME");
   if (nekrs_home == nullptr) {
     if (rank == 0)
-      cout << "\nERROR: The environment variable NEKRS_HOME is not defined!\n";
+      std::cout << "\nERROR: The environment variable NEKRS_HOME is not defined!\n";
     EXIT(1);
   }
   string install_dir{nekrs_home};
@@ -33,7 +33,7 @@ void configRead(MPI_Comm comm)
   const char* ptr = realpath(configFile.c_str(), NULL);
   if (!ptr) {
     if (rank == 0) 
-      cout << "\nERROR: Cannot find " << configFile << "!\n";
+      std::cout << "\nERROR: Cannot find " << configFile << "!\n";
     EXIT(1);
   }
 

--- a/src/core/parReader.cpp
+++ b/src/core/parReader.cpp
@@ -16,7 +16,7 @@
 #define exit(a, b)                                                             \
   {                                                                            \
     if (rank == 0)                                                             \
-      cout << a << endl;                                                       \
+      std::cout << a << std::endl;                                             \
     EXIT(1);                                                                   \
   }
 #define UPPER(a)                                                               \
@@ -255,7 +255,7 @@ setupAide parRead(void *ppar, std::string setupFile, MPI_Comm comm) {
   const char *ptr = realpath(setupFile.c_str(), NULL);
   if (!ptr) {
     if (rank == 0)
-      cout << "\nERROR: Cannot find " << setupFile << "!\n";
+      std::cout << "\nERROR: Cannot find " << setupFile << "!\n";
     ABORT(1);
   }
 

--- a/src/core/printHeader.cpp
+++ b/src/core/printHeader.cpp
@@ -1,12 +1,12 @@
 void printHeader()
 {
-  cout << R"(                 __    ____  _____)" << endl
-       << R"(   ____   ___   / /__ / __ \/ ___/)" << endl
-       << R"(  / __ \ / _ \ / //_// /_/ /\__ \ )" << endl
-       << R"( / / / //  __// ,<  / _, _/___/ / )" << endl
-       << R"(/_/ /_/ \___//_/|_|/_/ |_|/____/  )"
-       << "v" << NEKRS_VERSION << "." << NEKRS_SUBVERSION << "." << NEKRS_PATCHVERSION << GITCOMMITHASH << endl
-       << endl
-       << "COPYRIGHT (c) 2019-2021 UCHICAGO ARGONNE, LLC" << endl
-       << endl;
+  std::cout << R"(                 __    ____  _____)" << std::endl
+            << R"(   ____   ___   / /__ / __ \/ ___/)" << std::endl
+            << R"(  / __ \ / _ \ / //_// /_/ /\__ \ )" << std::endl
+            << R"( / / / //  __// ,<  / _, _/___/ / )" << std::endl
+            << R"(/_/ /_/ \___//_/|_|/_/ |_|/____/  )"
+            << "v" << NEKRS_VERSION << "." << NEKRS_SUBVERSION << "." << NEKRS_PATCHVERSION << GITCOMMITHASH << std::endl
+            << std::endl
+            << "COPYRIGHT (c) 2019-2021 UCHICAGO ARGONNE, LLC" << std::endl
+            << std::endl;
 }

--- a/src/core/setup.cpp
+++ b/src/core/setup.cpp
@@ -67,14 +67,14 @@ void nrsSetup(MPI_Comm comm, setupAide &options, nrs_t *nrs)
       nek::setup(comm, platform->options, nrs);
       nek::setic();
       nek::userchk();
-      if (platform->comm.mpiRank == 0) cout << "\n";
+      if (platform->comm.mpiRank == 0) std::cout << "\n";
     }
   }
 
   nrs->cht = 0;
   if (nekData.nelv != nekData.nelt && nrs->Nscalar) nrs->cht = 1;
   if (nrs->cht && !platform->options.compareArgs("SCALAR00 IS TEMPERATURE", "TRUE")) {
-    if (platform->comm.mpiRank == 0) cout << "Conjugate heat transfer requires solving for temperature!\n"; 
+    if (platform->comm.mpiRank == 0) std::cout << "Conjugate heat transfer requires solving for temperature!\n"; 
     ABORT(EXIT_FAILURE);;
   } 
 
@@ -151,7 +151,7 @@ void nrsSetup(MPI_Comm comm, setupAide &options, nrs_t *nrs)
       memcpy(nrs->weightsRK, rkb, nrs->nRK * sizeof(dfloat));
       memcpy(nrs->nodesRK, rkc, nrs->nRK * sizeof(dfloat));
     }else{
-      if(platform->comm.mpiRank == 0) cout << "Unsupported subcycling scheme!\n";
+      if(platform->comm.mpiRank == 0) std::cout << "Unsupported subcycling scheme!\n";
       ABORT(1);
     }
     nrs->o_coeffsfRK = device.malloc(nrs->nRK * sizeof(dfloat), nrs->coeffsfRK);
@@ -242,9 +242,9 @@ void nrsSetup(MPI_Comm comm, setupAide &options, nrs_t *nrs)
   if (udf.loadKernels) {
     occa::properties* tmpKernelInfo = nrs->kernelInfo;
     nrs->kernelInfo = &kernelInfoBC;
-    if (platform->comm.mpiRank == 0) cout << "loading udf kernels ... ";
+    if (platform->comm.mpiRank == 0) std::cout << "loading udf kernels ... ";
     udf.loadKernels(nrs);
-    if (platform->comm.mpiRank == 0) cout << "done" << endl;
+    if (platform->comm.mpiRank == 0) std::cout << "done" << std::endl;
     nrs->kernelInfo = tmpKernelInfo;
   }
   const string bcDataFile = install_dir + "/include/core/bcData.h";
@@ -592,7 +592,7 @@ void nrsSetup(MPI_Comm comm, setupAide &options, nrs_t *nrs)
       (is) ? mesh = cds->meshV : mesh = cds->mesh[0]; // only first scalar can be a CHT mesh
 
       if (platform->comm.mpiRank == 0)
-        cout << "================= ELLIPTIC SETUP SCALAR" << sid << " ===============\n";
+        std::cout << "================= ELLIPTIC SETUP SCALAR" << sid << " ===============\n";
 
       int nbrBIDs = bcMap::size(0);
       if(nrs->cht && is == 0) nbrBIDs = bcMap::size(1);

--- a/src/elliptic/ellipticMultiGridSetup.cpp
+++ b/src/elliptic/ellipticMultiGridSetup.cpp
@@ -63,7 +63,7 @@ void ellipticMultiGridSetup(elliptic_t* elliptic_, precon_t* precon)
     for(int i = 0; i < numMGLevels; ++i)
       levelDegree[i] = elliptic->levels[i];
   } else {
-    cout << "Unknown coarsening type!";
+    std::cout << "Unknown coarsening type!";
     MPI_Abort(platform->comm.mpiComm, 1);
   }
 

--- a/src/lib/nekrs.cpp
+++ b/src/lib/nekrs.cpp
@@ -27,16 +27,16 @@ static void dryRun(setupAide &options, int npTarget);
 
 void printHeader()
 {
-  cout << R"(                 __    ____  _____)" << endl
-       << R"(   ____   ___   / /__ / __ \/ ___/)" << endl
-       << R"(  / __ \ / _ \ / //_// /_/ /\__ \ )" << endl
-       << R"( / / / //  __// ,<  / _, _/___/ / )" << endl
-       << R"(/_/ /_/ \___//_/|_|/_/ |_|/____/  )"
-       << "v" << NEKRS_VERSION << "." << NEKRS_SUBVERSION 
-       << " (" << GITCOMMITHASH << ")" << endl
-       << endl
-       << "COPYRIGHT (c) 2019-2021 UCHICAGO ARGONNE, LLC" << endl
-       << endl;
+  std::cout << R"(                 __    ____  _____)" << std::endl
+            << R"(   ____   ___   / /__ / __ \/ ___/)" << std::endl
+            << R"(  / __ \ / _ \ / //_// /_/ /\__ \ )" << std::endl
+            << R"( / / / //  __// ,<  / _, _/___/ / )" << std::endl
+            << R"(/_/ /_/ \___//_/|_|/_/ |_|/____/  )"
+            << "v" << NEKRS_VERSION << "." << NEKRS_SUBVERSION 
+            << " (" << GITCOMMITHASH << ")" << std::endl
+            << std::endl
+            << "COPYRIGHT (c) 2019-2021 UCHICAGO ARGONNE, LLC" << std::endl
+            << std::endl;
 }
 
 namespace nekrs
@@ -75,11 +75,11 @@ void setup(MPI_Comm comm_in, int buildOnly, int commSizeTarget,
 
   if (rank == 0) {
     printHeader();
-    cout << "MPI tasks: " << size << endl << endl;
+    std::cout << "MPI tasks: " << size << std::endl << std::endl;
     string install_dir;
     install_dir.assign(getenv("NEKRS_HOME"));
-    cout << "using NEKRS_HOME: " << install_dir << endl;
-    cout << "using OCCA_CACHE_DIR: " << occa::env::OCCA_CACHE_DIR << endl << endl;
+    std::cout << "using NEKRS_HOME: " << install_dir << std::endl;
+    std::cout << "using OCCA_CACHE_DIR: " << occa::env::OCCA_CACHE_DIR << std::endl << std::endl;
   }
 
   nrs = new nrs_t();
@@ -124,7 +124,7 @@ void setup(MPI_Comm comm_in, int buildOnly, int commSizeTarget,
 
   options.setArgs("CI-MODE", std::to_string(ciMode));
   if(rank == 0 && ciMode)
-    cout << "enabling continous integration mode " << ciMode << "\n";
+    std::cout << "enabling continous integration mode " << ciMode << "\n";
 
   if(udf.setup0) udf.setup0(comm, options);
 
@@ -147,9 +147,9 @@ void setup(MPI_Comm comm_in, int buildOnly, int commSizeTarget,
   platform->timer.toc("setup");
   const double setupTime = platform->timer.query("setup", "DEVICE:MAX");
   if(rank == 0) {
-    cout << "\nsettings:\n" << endl << options << endl;
-    cout << "occa memory usage: " << platform->device.memoryAllocated()/1e9 << " GB" << endl;
-    cout << "initialization took " << setupTime << " s" << endl;
+    std::cout << "\nsettings:\n" << std::endl << options << std::endl;
+    std::cout << "occa memory usage: " << platform->device.memoryAllocated()/1e9 << " GB" << std::endl;
+    std::cout << "initialization took " << setupTime << " s" << std::endl;
   }
   fflush(stdout);
 
@@ -284,9 +284,9 @@ void printRuntimeStatistics()
 
 static void dryRun(setupAide &options, int npTarget)
 {
-  cout << "performing dry-run to jit-compile for >="
+  std::cout << "performing dry-run to jit-compile for >="
        << npTarget 
-       << " MPI tasks ...\n" << endl;
+       << " MPI tasks ...\n" << std::endl;
   fflush(stdout);	
 
   options.setArgs("NP TARGET", std::to_string(npTarget));
@@ -313,7 +313,7 @@ static void dryRun(setupAide &options, int npTarget)
   platform_t* platform = platform_t::getInstance();
   nrsSetup(comm, options, nrs);
 
-  cout << "\nBuild successful." << endl;
+  std::cout << "\nBuild successful." << std::endl;
 }
 
 static void setOUDF(setupAide &options)
@@ -325,7 +325,7 @@ static void setOUDF(setupAide &options)
 
   char* ptr = realpath(oklFile.c_str(), NULL);
   if(!ptr) {
-    if (rank == 0) cout << "ERROR: Cannot find " << oklFile << "!\n";
+    if (rank == 0) std::cout << "ERROR: Cannot find " << oklFile << "!\n";
     ABORT(EXIT_FAILURE);;
   }
   free(ptr);

--- a/src/linAlg/matrix.cpp
+++ b/src/linAlg/matrix.cpp
@@ -43,7 +43,7 @@ void matrix < float > ::symeig(matrix < float > &W, matrix < float > &V)
 
   //  ssyev_ (&JOBZ, &UPLO, &N, V.c_array(), &LDA, W.c_array(), WORK.c_array(), &LWORK, &INFO );
 
-  //  cout << "INFO: " << INFO << endl;
+  //  std::cout << "INFO: " << INFO << std::endl;
 }
 
 template < >
@@ -63,7 +63,7 @@ void matrix < double > ::symeig(matrix < double > &W, matrix < double > &V)
 
   //  dsyev_ (&JOBZ, &UPLO, &N, V.c_array(), &LDA, W.c_array(), WORK.c_array(), &LWORK, &INFO );
 
-  //  cout << "INFO: " << INFO << endl;
+  //  std::cout << "INFO: " << INFO << std::endl;
 }
 
 template < >
@@ -87,7 +87,7 @@ void matrix < float > ::eig(matrix < float > &WR, matrix < float > &WI,
 
   //  sgeev_ (&JOBVL, &JOBVR, &N, A.c_array(), &LDA, WR.c_array(), WI.c_array(), VL.c_array(), &LDA, VR.c_array(), &LDA, WORK.c_array(), &LWORK, &INFO);
 
-  //  cout << "INFO: " << INFO << endl;
+  //  std::cout << "INFO: " << INFO << std::endl;
 }
 
 template < >
@@ -111,7 +111,7 @@ void matrix < double > ::eig(matrix < double > &WR, matrix < double > &WI,
 
   //  dgeev_ (&JOBVL, &JOBVR, &N, A.c_array(), &LDA, WR.c_array(), WI.c_array(), VL.c_array(), &LDA, VR.c_array(), &LDA, WORK.c_array(), &LWORK, &INFO);
 
-  //  cout << "INFO: " << INFO << endl;
+  //  std::cout << "INFO: " << INFO << std::endl;
 }
 
 // general left matrix inverse not implemented
@@ -129,7 +129,7 @@ matrix < double > operator | (const matrix < double > &A, const matrix < double 
 
   matrix < int > IPIV(N,1);
 
-  //  cout << "NRHS: " << NRHS << endl;
+  //  std::cout << "NRHS: " << NRHS << std::endl;
 
   /* solve A*X = B for X */
 #if 0
@@ -161,8 +161,8 @@ matrix < float > operator | (const matrix < float > &A, const matrix < float > &
 
   matrix < int > IPIV(N,1);
 
-  //  cout << "NRHS: " << NRHS << endl;
-  //  cout << "Acopy: " << Acopy << endl;
+  //  std::cout << "NRHS: " << NRHS << std::endl;
+  //  std::cout << "Acopy: " << Acopy << std::endl;
 
   /* solve A*X = B for X */
 #if 0

--- a/src/plugins/RANSktau.cpp
+++ b/src/plugins/RANSktau.cpp
@@ -80,7 +80,7 @@ void RANSktau::buildKernel(nrs_t* nrs)
   }
 
   if(nrs->Nscalar < 2) {
-    if(platform->comm.mpiRank == 0) cout << "RANSktau: Nscalar needs to be >= 2!\n";
+    if(platform->comm.mpiRank == 0) std::cout << "RANSktau: Nscalar needs to be >= 2!\n";
     ABORT(1);
   }
   platform->options.setArgs("STRESSFORMULATION", "TRUE");

--- a/src/plugins/avg.cpp
+++ b/src/plugins/avg.cpp
@@ -91,7 +91,7 @@ void avg::EXY(dlong N,
 void avg::run(dfloat time)
 {
   if(!setupCalled || !buildKernelCalled) {
-    cout << "avg::run() was called prior to avg::setup()!\n";
+    std::cout << "avg::run() was called prior to avg::setup()!\n";
     ABORT(1);
   }
 
@@ -143,7 +143,7 @@ void avg::run(dfloat time)
 void avg::setup(nrs_t* nrs_)
 {
   if(!buildKernelCalled) {
-    cout << "avg::setup() was called prior avg::buildKernel()!\n";
+    std::cout << "avg::setup() was called prior avg::buildKernel()!\n";
     ABORT(1);
   }
 

--- a/src/plugins/lowMach.cpp
+++ b/src/plugins/lowMach.cpp
@@ -51,7 +51,7 @@ void lowMach::setup(nrs_t* nrs, dfloat gamma)
   int err = 1;
   if(platform->options.compareArgs("SCALAR00 IS TEMPERATURE", "TRUE")) err = 0;
   if(err) {
-    if(platform->comm.mpiRank == 0) cout << "lowMach requires solving for temperature!\n";
+    if(platform->comm.mpiRank == 0) std::cout << "lowMach requires solving for temperature!\n";
     ABORT(1);
   } 
   platform->options.setArgs("LOWMACH", "TRUE"); 

--- a/src/timeStepper/timeStepper.cpp
+++ b/src/timeStepper/timeStepper.cpp
@@ -1301,7 +1301,7 @@ void printInfo(nrs_t *nrs, dfloat time, int tstep, double tElapsedStep, double t
   }
 
   if(cfl > 30 || std::isnan(cfl)) {
-    if(platform->comm.mpiRank == 0) cout << "Unreasonable CFL! Dying ...\n" << endl;
+    if(platform->comm.mpiRank == 0) std::cout << "Unreasonable CFL! Dying ...\n" << std::endl;
     ABORT(1);
   }
 


### PR DESCRIPTION
This PR replaces each occurrence of `cout` and `endl` with `std::cout` and `std::endl`, respectively. I believe this is the cause of some hiding of error messages from NekRS when run from within Cardinal, possibly due to some libMesh manipulations of the `std` namespace.