### PR TITLE
Free MPI communicators and windows before calling `MPI_Finalize`

### DIFF
--- a/3rd_party/nek5000/core/dprocmap.f
+++ b/3rd_party/nek5000/core/dprocmap.f
@@ -36,6 +36,22 @@ c-----------------------------------------------------------------------
       return
       end
 c-----------------------------------------------------------------------
+      subroutine dProcmapFinalize()
+
+      include 'mpif.h'
+      include 'SIZE'
+      include 'PARALLEL'
+      include 'DPROCMAP'
+
+#ifdef MPI
+      integer ierr
+      call MPI_Win_free(dProcmapH,ierr)
+      if (ierr .ne. 0 ) call exitti('MPI_Win_free failed!$',0)
+#endif
+
+      return
+      end
+c-----------------------------------------------------------------------
       subroutine dProcmapPut(ibuf,lbuf,ioff,ieg)
 
       include 'mpif.h'

--- a/3rd_party/nek5000/core/drive1.f
+++ b/3rd_party/nek5000/core/drive1.f
@@ -333,16 +333,16 @@ c-----------------------------------------------------------------------
       include 'SIZE'
       include 'TOTAL'
 
-      if(instep.ne.0) call runstat
+c      if(instep.ne.0) call runstat
 
 c      if (ifstrs) then
 c         call fgslib_crs_free(xxth_strs) 
 c      else
 c         call fgslib_crs_free(xxth(1))
 c      endif
-
-      call in_situ_end()
-      call exitt0()
+       call dProcmapFinalize()
+c      call in_situ_end()
+c      call exitt0()
 
       return
       end

--- a/src/core/platform.hpp
+++ b/src/core/platform.hpp
@@ -86,6 +86,11 @@ struct comm_t{
     ss << "localRank = " << localRank << std::endl;
     return ss.str();
   }
+
+  void finalize() {
+    if(MPI_COMM_NULL != mpiCommLocal)
+      MPI_Comm_free(&mpiCommLocal);
+  }
 };
 
 struct platform_t{

--- a/src/lib/nekrs.cpp
+++ b/src/lib/nekrs.cpp
@@ -345,6 +345,13 @@ void* nrsPtr(void)
 void finalize(void)
 {
   AMGXfree();
+  nek::end();
+  
+  if(nullptr != platform)
+    platform->comm.finalize();
+  
+  MPI_Comm_free(&comm);
+  MPI_Comm_free(&commg);
 }
 
 void printRuntimeStatistics(int step)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -243,6 +243,8 @@ MPI_Comm setupSession(cmdOptions* cmdOpt, const MPI_Comm &comm)
   int rank, size;
   MPI_Comm_rank(comm, &rank);
   MPI_Comm_size(comm, &size);
+  // Communicator is copied, not duplicated; therefore, it does not need to be freed.
+  // Should this be `MPI_Comm_dup(comm,&newComm);`?
   MPI_Comm newComm = comm;
 
   if(cmdOpt->multiSessionFile.size()) {
@@ -481,6 +483,9 @@ int main(int argc, char** argv)
   nekrs::finalize();
 
   MPI_Barrier(commGlobal);
+  // Communicator is copied, not duplicated; therefore, it does not need to be freed
+  // MPI_Comm_free(&comm);
+  MPI_Comm_free(&commGlobal);
   MPI_Finalize();
   return EXIT_SUCCESS;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -243,8 +243,6 @@ MPI_Comm setupSession(cmdOptions* cmdOpt, const MPI_Comm &comm)
   int rank, size;
   MPI_Comm_rank(comm, &rank);
   MPI_Comm_size(comm, &size);
-  // Communicator is copied, not duplicated; therefore, it does not need to be freed.
-  // Should this be `MPI_Comm_dup(comm,&newComm);`?
   MPI_Comm newComm = comm;
 
   if(cmdOpt->multiSessionFile.size()) {
@@ -418,6 +416,7 @@ int main(int argc, char** argv)
 
   if (cmdOpt->buildOnly) {
     nekrs::finalize();
+    MPI_Comm_free(&commGlobal);
     MPI_Finalize();
     return EXIT_SUCCESS;
   }
@@ -483,8 +482,6 @@ int main(int argc, char** argv)
   nekrs::finalize();
 
   MPI_Barrier(commGlobal);
-  // Communicator is copied, not duplicated; therefore, it does not need to be freed
-  // MPI_Comm_free(&comm);
   MPI_Comm_free(&commGlobal);
   MPI_Finalize();
   return EXIT_SUCCESS;

--- a/src/nekInterface/nekInterfaceAdapter.cpp
+++ b/src/nekInterface/nekInterfaceAdapter.cpp
@@ -9,6 +9,7 @@ nekdata_private nekData;
 static int rank;
 static setupAide* options;
 static nrs_t* nrs;
+static bool nek_is_setup = false;
 
 static void (* usrdat_ptr)(void);
 static void (* usrdat2_ptr)(void);
@@ -158,7 +159,8 @@ void uic(int ifield)
 
 void end()
 {
-  (*nek_end_ptr)();
+  if(nek_is_setup)
+    (*nek_end_ptr)();
 }
 
 void setic(void)
@@ -691,6 +693,8 @@ int setup(nrs_t* nrs_in)
 
   (*nek_setup_ptr)(&flow, &nscal, &nBcRead, &meshPartType, &meshConTol,
 		   &rho, &mue, &rhoCp, &lambda); 
+
+  nek_is_setup = true;
 
   nekData.param = (double*) ptr("param");
   nekData.ifield = (int*) ptr("ifield");


### PR DESCRIPTION
Closes #402

Free MPI communicators and windows to avoid errors from calling `MPI_Finalize` when using MPICH.