### PR TITLE
Re-add mesh_t::NboundaryFaces

### DIFF
--- a/src/mesh/mesh.h
+++ b/src/mesh/mesh.h
@@ -70,6 +70,7 @@ struct mesh_t
   dlong Nelements;
   dlong fieldOffset;
   dlong Nlocal;
+  hlong NboundaryFaces;
   hlong* EToV; // element-to-vertex connectivity
   dlong* EToE; // element-to-element connectivity
   int* EToF;   // element-to-(local)face connectivity

--- a/src/mesh/meshNekReader.cpp
+++ b/src/mesh/meshNekReader.cpp
@@ -55,6 +55,7 @@ void meshNekReaderHex3D(int N, mesh_t* mesh)
   MPI_Allreduce(MPI_IN_PLACE, &NboundaryFaces, 1, MPI_HLONG, MPI_SUM, platform->comm.mpiComm);
   if (platform->comm.mpiRank == 0)
     printf("NboundaryIDs: %d, NboundaryFaces: %lld ", Nbid, NboundaryFaces);
+  mesh->NboundaryFaces = NboundaryFaces;
 
   // boundary face tags (face numbering is in pre-processor notation)
   mesh->EToB = (int*) calloc(mesh->Nelements * mesh->Nfaces, sizeof(int));


### PR DESCRIPTION
Cardinal relies upon this data member, which was deleted in the latest next update. This is much simpler for us than recomputing it.