### PR TITLE
Fix uninitialized memory errors in occa when array sizes are zero

### DIFF
--- a/src/solvers/elliptic/MG/coarseLevel.cpp
+++ b/src/solvers/elliptic/MG/coarseLevel.cpp
@@ -70,8 +70,8 @@ void MGSolver_t::coarseLevel_t::setupSolver(
   if (!vectorDotStarKernel.isInitialized()) 
     vectorDotStarKernel = platform->kernels.get(kernelName);
 
-  o_xBuffer = platform->device.malloc(N * sizeof(pfloat));
-  h_xBuffer = platform->device.mallocHost(N * sizeof(pfloat));
+  o_xBuffer = platform->device.malloc((N + 1) * sizeof(pfloat));
+  h_xBuffer = platform->device.mallocHost((N + 1) * sizeof(pfloat));
   xBuffer = (pfloat*) h_xBuffer.ptr(); 
 
   if (options.compareArgs("COARSE SOLVER", "BOOMERAMG")){

--- a/src/solvers/elliptic/MG/ellipticMultiGridSetup.cpp
+++ b/src/solvers/elliptic/MG/ellipticMultiGridSetup.cpp
@@ -286,9 +286,9 @@ void ellipticMultiGridSetup(elliptic_t *elliptic_, precon_t *precon_)
       coarseLevel->o_weight = ellipticCoarse->o_invDegree;
       coarseLevel->weight = (pfloat *)calloc(ellipticCoarse->mesh->Nlocal, sizeof(pfloat));
       coarseLevel->o_weight.copyTo(coarseLevel->weight, ellipticCoarse->mesh->Nlocal * sizeof(pfloat));
-      coarseLevel->h_Gx = platform->device.mallocHost(coarseLevel->ogs->Ngather * sizeof(pfloat));
+      coarseLevel->h_Gx = platform->device.mallocHost((coarseLevel->ogs->Ngather + 1) * sizeof(pfloat));
       coarseLevel->Gx = (pfloat *)coarseLevel->h_Gx.ptr();
-      coarseLevel->o_Gx = platform->device.malloc(coarseLevel->ogs->Ngather * sizeof(pfloat));
+      coarseLevel->o_Gx = platform->device.malloc((coarseLevel->ogs->Ngather + 1) * sizeof(pfloat));
       coarseLevel->h_Sx = platform->device.mallocHost(ellipticCoarse->mesh->Nlocal * sizeof(pfloat));
       coarseLevel->Sx = (pfloat *)coarseLevel->h_Sx.ptr();
       coarseLevel->o_Sx = platform->device.malloc(ellipticCoarse->mesh->Nlocal * sizeof(pfloat));


### PR DESCRIPTION
At `E/P = 1`, `examples/channel` threw an uninitialized memory error in occa
due to these quantities (`N` and `ogs->Ngather`) being zero (or at lest one of
them, but it is best to guard both for future errors).