### PR TITLE
Enable new tavg plugin for CHT use

### DIFF
--- a/src/plugins/tavg.hpp
+++ b/src/plugins/tavg.hpp
@@ -18,14 +18,17 @@
 #include "nekInterfaceAdapter.hpp"
 
 #include <vector>
+#include <utility>
 
 namespace tavg
 {
-typedef std::vector< std::vector<occa::memory> > fields;
+typedef std::vector<std::vector<occa::memory>> simplefields;
+typedef std::vector<std::pair<std::vector<occa::memory>, mesh_t *>> fields;
 
 void buildKernel(occa::properties kernelInfo);
 void run(dfloat time);
 void setup(nrs_t *nrs_, const fields& fields);
+void setup(nrs_t *nrs_, const simplefields &fields);
 void setup(nrs_t* nrs_);
 void outfld();
 void outfld(int outXYZ, int FP64);


### PR DESCRIPTION
Since v23, the tavg module allows to specify the fields (and pointwise products) to be averaged. However the kernel always operated on the size of the vmesh only, i.e. when passing the temperature (or any other field defined on the tmesh), the values in the solid were ignored.

With this change, one may specify which mesh the kernel operates on alongside each vector of fields. If this is omitted, the vmesh is used. 

The `conj_ht` example is not really suited for turbulent averaging, any suggestions where to put an example of the new functionality?