### PR TITLE
Duplicate function definition

### DIFF
--- a/src/solvers/cvode/cvode.cpp
+++ b/src/solvers/cvode/cvode.cpp
@@ -61,10 +61,6 @@ cvode_t::~cvode_t()
 {
 }
 
-void cvode_t::initialize()
-{
-}
-
 void cvode_t::setupEToLMapping()
 {
 }


### PR DESCRIPTION
The `next` branch does not compile as-is, because there is a duplicate function definition,

```
/home/anovak/nekRS/src/solvers/cvode/cvode.cpp:64:6: error: redefinition of ‘void cvode_t::initialize()’
   64 | void cvode_t::initialize()
      |      ^~~~~~~
/home/anovak/nekRS/src/solvers/cvode/cvode.cpp:56:6: note: ‘void cvode_t::initialize()’ previously defined here
   56 | void cvode_t::initialize()
```