### PR TITLE
Update polyfill.hpp

### DIFF
--- a/3rd_party/occa/src/occa/internal/modes/dpcpp/polyfill.hpp
+++ b/3rd_party/occa/src/occa/internal/modes/dpcpp/polyfill.hpp
@@ -7,6 +7,7 @@
 #include <sycl.hpp>
 #else
 #include <vector>
+#include <cstdint>
 namespace sycl {
 
 class device;


### PR DESCRIPTION
#include <cstdint> needed to be added otherwise would cause this error:

nekRS-23.0/3rd_party/occa/src/occa/internal/modes/dpcpp/polyfill.hpp:10:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?