### PR TITLE
Add include file.

### DIFF
--- a/src/lib/nekrs.hpp
+++ b/src/lib/nekrs.hpp
@@ -4,6 +4,7 @@
 #include <mpi.h>
 #include <functional> 
 #include <string>
+#include "inipp.hpp"
 
 namespace nekrs
 {


### PR DESCRIPTION
I think this include file is missing -- in NekRS standalone this ends up being fine because `#include inipp.hpp` exists just above `#include nekrs.hpp` in `main.cpp`, but in Cardinal we `#include` `nekrs.hpp` in other files where it would be nice not to have to `#include inipp.hpp` before every call to `#include nekrs.hpp`.