### PR TITLE
Correct initial condition in turbChannel

### DIFF
--- a/examples/turbChannel/turbChannel.udf
+++ b/examples/turbChannel/turbChannel.udf
@@ -43,7 +43,7 @@ void useric(nrs_t *nrs)
   platform->options.getArgs("VISCOSITY", mue);
 
   if (platform->options.getArgs("RESTART FILE NAME").empty()) {
-    for (int i = 1; i < mesh->Nlocal; i++) {
+    for (int i = 0; i < mesh->Nlocal; i++) {
       const auto x = mesh->x[i];
       const auto y = mesh->y[i];
       const auto z = mesh->z[i];


### PR DESCRIPTION
Likely solution to https://github.com/Nek5000/nekRS/discussions/562, at least this fixes the issue for me. 

Grepping `for.*\([a-z]+ [a-z]+ = 1.*Nlocal` doesn' yield any other results, so hopefully this is the only occurrence. 