### PR TITLE
Fix Build Process for Apple M3 Processors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,23 +89,8 @@ endif()
 string(COMPARE EQUAL "${CMAKE_CXX_COMPILER_ID}" "AppleClang" USING_APPLE_LLVM)
 string(COMPARE EQUAL "${CMAKE_CXX_COMPILER_ID}" "NVHPC" USING_NVHPC)
 
-execute_process(
-    COMMAND sysctl -n machdep.cpu.brand_string
-    OUTPUT_VARIABLE CPU_BRAND_STRING
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-if(CPU_BRAND_STRING MATCHES "Apple M3")
-  set(IS_APPLE_M3 TRUE)
-else()
-  set(IS_APPLE_M3 FALSE)
-endif()
-
 if(USING_GNU OR USING_LLVM OR USING_APPLE_LLVM)
-  set(NEKRS_COMPILER_DEFAULT_FLAGS "-O2 -g -march=native -mtune=native -ftree-vectorize")
-  if(IS_APPLE_M3)
-    set(NEKRS_COMPILER_DEFAULT_FLAGS "-O2 -g -mcpu=native -ftree-vectorize")
-  endif()
+  set(NEKRS_COMPILER_DEFAULT_FLAGS "-O2 -g -march=native -ftree-vectorize")
   if (USING_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1)
     message(FATAL_ERROR "GNU compiler version must be at least 9.1!")
   endif()
@@ -127,10 +112,7 @@ set(OCCA_CXX "${MPI_UNDERLYING_COMPILER}" CACHE STRING "C++ compiler for OCCA JI
 if(USING_INTEL_LLVM)
   set(OCCA_CXXFLAGS "-w -O3 -g" CACHE STRING "C++ flags for OCCA JIT compile")
 elseif(USING_GNU OR USING_LLVM OR USING_APPLE_LLVM)
-  set(OCCA_CXXFLAGS "-w -O3 -g -march=native -mtune=native -ffast-math" CACHE STRING "C++ flags for OCCA JIT compile")
-  if(IS_APPLE_M3)
-    set(OCCA_CXXFLAGS "-w -O3 -g -mcpu=native -ffast-math" CACHE STRING "C++ flags for OCCA JIT compile")
-  endif()
+  set(OCCA_CXXFLAGS "-w -O3 -g -march=native -ffast-math" CACHE STRING "C++ flags for OCCA JIT compile")
   
 elseif(USING_NVHPC)
   set(OCCA_CXXFLAGS "-w -O3 -g -fast" CACHE STRING "C++ flags for OCCA JIT compile")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,8 +89,23 @@ endif()
 string(COMPARE EQUAL "${CMAKE_CXX_COMPILER_ID}" "AppleClang" USING_APPLE_LLVM)
 string(COMPARE EQUAL "${CMAKE_CXX_COMPILER_ID}" "NVHPC" USING_NVHPC)
 
+execute_process(
+    COMMAND sysctl -n machdep.cpu.brand_string
+    OUTPUT_VARIABLE CPU_BRAND_STRING
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if(CPU_BRAND_STRING MATCHES "Apple M3")
+  set(IS_APPLE_M3 TRUE)
+else()
+  set(IS_APPLE_M3 FALSE)
+endif()
+
 if(USING_GNU OR USING_LLVM OR USING_APPLE_LLVM)
   set(NEKRS_COMPILER_DEFAULT_FLAGS "-O2 -g -march=native -mtune=native -ftree-vectorize")
+  if(IS_APPLE_M3)
+    set(NEKRS_COMPILER_DEFAULT_FLAGS "-O2 -g -mcpu=native -ftree-vectorize")
+  endif()
   if (USING_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1)
     message(FATAL_ERROR "GNU compiler version must be at least 9.1!")
   endif()
@@ -113,6 +128,10 @@ if(USING_INTEL_LLVM)
   set(OCCA_CXXFLAGS "-w -O3 -g" CACHE STRING "C++ flags for OCCA JIT compile")
 elseif(USING_GNU OR USING_LLVM OR USING_APPLE_LLVM)
   set(OCCA_CXXFLAGS "-w -O3 -g -march=native -mtune=native -ffast-math" CACHE STRING "C++ flags for OCCA JIT compile")
+  if(IS_APPLE_M3)
+    set(OCCA_CXXFLAGS "-w -O3 -g -mcpu=native -ffast-math" CACHE STRING "C++ flags for OCCA JIT compile")
+  endif()
+  
 elseif(USING_NVHPC)
   set(OCCA_CXXFLAGS "-w -O3 -g -fast" CACHE STRING "C++ flags for OCCA JIT compile")
 else()


### PR DESCRIPTION
### Description:
This PR introduces changes to the `CMakeLists.txt` file to support compilation for the Apple M3 architecture. Initially, the following errors were encountered due to incorrect or unsupported compiler flags for the M3 processor.

### Errors Encountered:
1. **-march**
   During the build, the following error was thrown:

   ```
   f951: Error: unknown value 'apple-m3' for '-march'
   f951: note: valid arguments are: armv8-a armv8.1-a armv8.2-a armv8.3-a armv8.4-a armv8.5-a armv8.6-a armv8.7-a armv8.8-a armv8.9-a armv8-r armv9-a armv9.1-a armv9.2-a armv9.3-a armv9.4-a native
   f951: note: did you mean '-mcpu=apple-m3'?
   ```

   This error occurred because the compiler does not recognize `-march=apple-m3`, but rather, it suggests using `-mcpu=apple-m3`.

2. **-mtune** 
   After correcting the `-march` flag, the following error was encountered:

   ```
   -mtune =  error: unsupported argument 'apple-m3' to option '-mtune='
   ```

   This error occurred because the `-mtune` flag does not support `apple-m3` as a valid argument.

### Changes Made:
To address these issues, the following changes were made to the `CMakeLists.txt` file:

1. **Processor Detection for Apple M3**:  
   A check was added for detecting the Apple M3 architecture using `sysctl -n machdep.cpu.brand_string` to get the processer name. If the brand string contains Apple M3, the code changes certain compiler flags
2. **Corrected Compiler Flags**:
   - Only in the case when an Apple M3 processor is detected, the two compiler flags are changed:
   - **For `-march`**: The incorrect `-march=native` was replaced with `-mcpu=native`, which is the correct flag to target Apple M3 processors.
   - **For `-mtune`**: The `-mtune=native` flag was removed, as it is not supported.