### PR TITLE
Planar averaging for cylindrical domains

### DIFF
--- a/src/mesh/kernels/gatherPlanarValuesCyl.okl
+++ b/src/mesh/kernels/gatherPlanarValuesCyl.okl
@@ -1,0 +1,29 @@
+// pre: result is 0 initialized
+@kernel void gatherPlanarValuesCyl(const dlong Nelements,
+                                   const dlong Nfields,
+                                   const dlong fieldOffset,
+                                   const dlong nelxy,
+                                   const dlong nelz,
+                                   @ restrict const dlong *locToGlobE,
+                                   @ restrict const dfloat *field,
+                                   @ restrict dfloat *result)
+{
+  for (dlong e = 0; e < Nelements; e++; @outer(0)) {
+    dlong ez;
+    get_ez_cyl(&ez, locToGlobE[e], nelxy);
+
+    for (int fld = 0; fld < Nfields; ++fld) {
+      for (int k = 0; k < p_Nq; ++k; @inner(0)) {
+        dfloat gatheredValue = 0.0;
+        for (int j = 0; j < p_Nq; ++j) {
+          for (int i = 0; i < p_Nq; ++i) {
+            const dlong id = e * p_Np + i + j * p_Nq + k * p_Nq * p_Nq;
+            gatheredValue += field[id + fld * fieldOffset];
+          }
+        }
+        const dlong offset = nelz * p_Nq * fld;
+        @atomic result[ez * p_Nq + k + offset] += gatheredValue;
+      }
+    }
+  }
+}

--- a/src/mesh/kernels/planarAveraging.h
+++ b/src/mesh/kernels/planarAveraging.h
@@ -19,3 +19,17 @@ void get_exyz(int* ex, int* ey, int* ez, int eg, int nelx, int nely, int nelz)
   (*ez)--;
 
 }
+
+// For xy-planar averaging within cylindrical
+// domains aligned along the z-axis
+void get_ez_cyl(int* ez, int eg, int nelxy)
+{
+  // convert 0-based indexing to 1-based indexing
+  eg++;
+
+  // compute based on 1-based indexing
+  *ez = 1 + (eg-1)/(nelxy);
+
+  // shift back to 0-based indexing
+  (*ez)--;
+}

--- a/src/mesh/kernels/scatterPlanarValuesCyl.okl
+++ b/src/mesh/kernels/scatterPlanarValuesCyl.okl
@@ -1,0 +1,30 @@
+@kernel void scatterPlanarValuesCyl(const dlong Nelements,
+                                    const dlong Nfields,
+                                    const dlong fieldOffset,
+                                    const dlong nelxy,
+                                    const dlong nelz,
+                                    @ restrict const dlong *locToGlobE,
+                                    @ restrict const dfloat *field,
+                                    @ restrict dfloat *result)
+{
+  for (dlong e = 0; e < Nelements; e++; @outer(0)) {
+    dlong ez;
+    get_ez_cyl(&ez, locToGlobE[e], nelxy);
+
+    // The below value was 1/nelx for planar averaging in box
+    const dfloat invNelx = 1.0 / sqrt( (float) nelxy);
+
+    for (int fld = 0; fld < Nfields; ++fld) {
+      for (int k = 0; k < p_Nq; ++k; @inner(0)) {
+        const dlong offset = nelz * p_Nq * fld;
+        const dfloat value = field[ez * p_Nq + k + offset];
+        for (int j = 0; j < p_Nq; ++j) {
+          for (int i = 0; i < p_Nq; ++i) {
+            const dlong id = e * p_Np + i + j * p_Nq + k * p_Nq * p_Nq;
+            result[id + fld * fieldOffset] = value * invNelx;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/mesh/mesh.h
+++ b/src/mesh/mesh.h
@@ -294,6 +294,13 @@ void planarAvg(mesh_t *mesh,
                dlong offset,
                occa::memory &o_avg);
 
+void planarAvgCyl(mesh_t *mesh,
+                  int NELGXY,
+                  int NELGZ,
+                  int nflds,
+                  dlong offset,
+                  occa::memory &o_avg);
+
 void meshPartitionStatistics(mesh_t *mesh);
 
 void meshParallelGatherScatterSetup(mesh_t *mesh,

--- a/src/mesh/registerMeshKernels.cpp
+++ b/src/mesh/registerMeshKernels.cpp
@@ -151,7 +151,7 @@ void registerMeshKernels(occa::properties kernelInfoBC)
       fileName = oklpath + "/core/linAlg/" + kernelName + ".okl";
       platform->kernelRequests.add("hlong-" + meshPrefix + kernelName, fileName, hlongSumKernelInfo);
 
-      for (const std::string dir : {"XY", "XZ", "YZ"}) {
+      for (const std::string dir : {"XY", "XZ", "YZ", "Cyl"}) {
         auto props = kernelInfo;
         props["includes"].asArray();
         props["includes"] += oklpath + "/mesh/planarAveraging.h";


### PR DESCRIPTION
# Cylindrical Planar Averaging

The existing planar averaging routines work only for cubical domains. To include averaging for cylindrical domains as well (along vertical Z direction for cases like thermal convection in a closed vertical cylinder), the following files are added:

1. `/src/mesh/kernels/gatherPlanarValuesCyl.okl` is based on `gatherPlanarValuesXY.okl` available in the same directory.
2. `/src/mesh/kernels/scatterPlanarValuesCyl.okl` is based on `scatterPlanarValuesXY.okl` available in the same directory.

The following files have new functions added to them:

1. `/src/mesh/kernels/planarAveraging.h` has the new function `get_ez_cyl`
2. `/src/mesh/mesh.h` has the new function declaration `planarAvgCyl`
3. `/src/mesh/planarAvg.cpp` have two new functions - `fusedPlanarAvgCyl` and `planarAvgCyl`

Finally, the following file has been modified to include `Cyl` as an added option for averaging apart from the existing `XY`, `XZ` and `YZ` options:

1. `/src/mesh/registerMeshKernels.cpp` line 154 within the function `registerMeshKernels`

Anyone who wishes to use cylindrical averaging need to specify number of spectral elements in the `XY` plane (the circular disc) and the number of elements along the `Z` direction.