### PR TITLE
Fix HYPRE device build failure with NEKRS_GPU_MPI=ON

### DIFF
--- a/cmake/hypre.cmake
+++ b/cmake/hypre.cmake
@@ -89,7 +89,7 @@ elseif(OCCA_HIP_ENABLED)
 endif()
 
 if(NEKRS_GPU_MPI)
-  list(APPEND HYPRE_CONFIGURE_FLAGS "--enable-gpu-aware-mpi --with-cxxstandard=17")
+  list(APPEND HYPRE_CONFIGURE_FLAGS "--enable-gpu-aware-mpi" "--with-cxxstandard=17")
 endif()
 
   set(HYPRE_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/HYPRE_BUILD_DEVICE-prefix)


### PR DESCRIPTION
The two configure flags were passed as a single string in the CMake list, causing HYPRE's configure to parse them as one argument:
  configure: error: invalid feature name: 'gpu-aware-mpi --with-cxxstandard'

Split into separate list elements so each flag is passed correctly.