### PR TITLE
Add UDF_Finalize as an entry point

### DIFF
--- a/src/core/udf/udf.cpp
+++ b/src/core/udf/udf.cpp
@@ -285,6 +285,7 @@ void udfLoad()
   *(void **)(&udf.autoloadKernels) = udfLoadFunction("UDF_AutoLoadKernels", 0);
   *(void **)(&udf.autoloadPlugins) = udfLoadFunction("UDF_AutoLoadPlugins", 1);
   *(void **)(&udf.executeStep) = udfLoadFunction("UDF_ExecuteStep", 1);
+  *(void **)(&udf.finalize) = udfLoadFunction("UDF_Finalize", 0);
 }
 
 void udfEcho()

--- a/src/core/udf/udf.hpp
+++ b/src/core/udf/udf.hpp
@@ -14,6 +14,7 @@ void UDF_LoadKernels(deviceKernelProperties& kernelInfo);
 void UDF_AutoLoadKernels(occa::properties &kernelInfo);
 void UDF_AutoLoadPlugins(occa::properties &kernelInfo);
 void UDF_ExecuteStep(double time, int tstep);
+void UDF_Finalize();
 }
 
 using udfsetup0 = void (*)(MPI_Comm, setupAide &);
@@ -22,6 +23,7 @@ using udfloadKernels = void (*)(deviceKernelProperties &);
 using udfautoloadKernels = void (*)(occa::properties &);
 using udfautoloadPlugins = void (*)(occa::properties &);
 using udfexecuteStep = void (*)(double, int);
+using udffinalize = void (*)();
 
 struct UDF {
   udfsetup0 setup0;
@@ -30,6 +32,7 @@ struct UDF {
   udfautoloadKernels autoloadKernels;
   udfautoloadPlugins autoloadPlugins;
   udfexecuteStep executeStep;
+  udffinalize finalize;
 };
 
 extern UDF udf;

--- a/src/lib/nekrs.cpp
+++ b/src/lib/nekrs.cpp
@@ -691,6 +691,11 @@ int finalize()
     hypreWrapper::finalize();
     hypreWrapperDevice::finalize();
     AMGXfinalize();
+
+    if (udf.finalize) {
+      udf.finalize();
+    }
+
     nek::finalize();
   }
 


### PR DESCRIPTION
Add `UDF_Finalize` as an entry point. 

This is a commonly used function name to finalize user defined functions.

The same can be achieved calling `if (nrs->lastStep)` in `UDF_ExecuteStep` currently, but this is a bit clunky.
`Finalize` maps nicely to e.g. the ParaView Catalyst API.
