### PR TITLE
Add agent skill for generating nekRS case files from physics descriptions

### DIFF
--- a/.claude/skills/udf-generator/SKILL.md
+++ b/.claude/skills/udf-generator/SKILL.md
@@ -104,6 +104,15 @@ Check the generated files for consistency:
 - For constant pressure-gradient driven flows, prefer `constFlowRate` in `[GENERAL]` over manual forcing
 - `regularization = hpfrt` requires `+nModes=<int>+scalingCoeff=<float>` — omitting either causes errors
 - Never include `ci.inc` or CI-related code in generated cases — that's for regression tests only
+- **Include paths**: use `#include "RANSktau.hpp"`, `#include "tavg.hpp"`, `#include "lowMach.hpp"` — NOT `#include "plugins/RANSktau.hpp"`. Match the style used in existing examples.
+- **Do not use `usrwrk` for constant BC values.** For uniform or constant boundary values, pass them as compile-time constants via `UDF_LoadKernels` using `kernelInfo.define("p_MY_CONST") = value`, then reference `p_MY_CONST` directly in OKL code. Reserve `usrwrk` for spatially/temporally varying BC data computed on the host.
+- **Do not generate dead code.** Only include OKL kernels and helper functions that are actually called. For example, do not include a `scalarScaledAdd` kernel unless the case has a temperature scalar with turbulent diffusion.
+- **Always include `UDF_LoadKernels`** if the UDF defines any OKL kernels or uses compile-time constants in `#ifdef __okl__` blocks. Even an empty body is fine.
+- **IC vector sizing**: use `nrs->fluid->fieldOffsetSum` for velocity IC vectors (not `mesh->dim * nrs->fluid->fieldOffset`). This is the idiomatic pattern from existing examples.
+- **Do not duplicate `.par` settings in code.** If `equation = navierStokes+variableViscosity` is in the `.par` file, do not also call `options.setArgs("PROBLEMTYPE EQUATION", ...)` in `UDF_Setup0`. Pick one place.
+- **CFL defaults**: for RANS cases use `targetCFL=0.5+initial=1e-3` (conservative). For well-resolved DNS/LES, `targetCFL=2.0` is acceptable. Do not use very small initial dt (e.g., 1e-6) unless the physics demands it.
+- **Always set `stopAt` explicitly** in `[GENERAL]` (e.g., `stopAt = numSteps` or `stopAt = endTime`). The default is `numSteps` but reference examples always state it explicitly for clarity.
+- **Always add `userSections = CASEDATA`** in `[GENERAL]` when the `.par` file includes a `[CASEDATA]` section. This is the documented pattern used by reference examples (e.g., `ethier.par`).
 
 ## File Templates
 
@@ -112,10 +121,12 @@ Check the generated files for consistency:
 ```ini
 [GENERAL]
 polynomialOrder = 7
+stopAt = numSteps
 numSteps = 1000
 dt = 1e-03
 timeStepper = tombo2
 checkpointInterval = 500
+userSections = CASEDATA
 
 [FLUID VELOCITY]
 boundaryTypeMap = <types matching mesh boundary IDs>
@@ -125,6 +136,9 @@ density = 1.0
 
 [FLUID PRESSURE]
 residualTol = 1e-04
+
+[CASEDATA]
+# user-defined parameters here
 ```
 
 ### Minimal `.udf` Template

--- a/.claude/skills/udf-generator/SKILL.md
+++ b/.claude/skills/udf-generator/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: udf-generator
+description: >
+  Generate nekRS simulation case files (.udf, .par, .oudf) from a user's
+  physics description. Use when the user describes a CFD simulation setup
+  including flow conditions (Reynolds number, Mach number), boundary
+  conditions (inlet, outlet, wall), geometry, or physical models (turbulence,
+  heat transfer, multiphysics). Also use when the user asks to create, modify,
+  or set up a nekRS case, even if they don't mention "UDF" explicitly.
+compatibility: Requires nekRS codebase. Designed for Claude Code.
+allowed-tools: Bash(mkdir:*) Read Write Edit Glob Grep
+metadata:
+  author: nekRS
+  version: "1.0"
+---
+
+# nekRS UDF Case Generator
+
+Generate complete nekRS simulation cases from user physics descriptions.
+
+## Workflow
+
+### Step 1: Gather Requirements
+
+Extract these from the user's prompt. If any **critical** item is missing, ask before proceeding.
+
+**Critical (must know):**
+- Flow type: incompressible, low-Mach, Stokes
+- Boundary conditions: what happens at each boundary (wall, inlet, outlet, symmetry)
+- Fluid properties: Reynolds number OR viscosity/density directly
+- Domain: geometry description or existing `.re2` mesh file
+
+**Important (ask if ambiguous):**
+- Scalar transport: temperature, passive scalars, species
+- Turbulence modeling: DNS, LES (with regularization), RANS (k-tau)
+- Time stepping: steady vs transient, timestep size, duration
+- Source terms: body forces, buoyancy, Coriolis
+
+**Optional (use sensible defaults):**
+- Polynomial order (default: 7)
+- Time stepper (default: tombo2)
+- Solver tolerances (default: 1e-6 velocity, 1e-4 pressure)
+- Checkpointing (default: every 500 steps)
+
+### Step 2: Determine Case Type
+
+Match the user's description to one of these physics categories to choose the right pattern:
+
+| Category | Key Indicators | Callbacks Needed | Plugins |
+|----------|---------------|-----------------|---------|
+| Laminar flow | Low Re, no turbulence model | Minimal or none | - |
+| Turbulent flow (DNS/LES) | High Re, no model | `userSource` (forcing) | tavg |
+| RANS | Mentions k-tau, SST | `userSource`, `userProperties` | RANSktau, tavg |
+| Heat transfer | Temperature, Nusselt, Prandtl | `userProperties` (if variable) | - |
+| Conjugate HT | Solid+fluid thermal | `userProperties` | - |
+| Low-Mach | Variable density, large dT | `userDivergence`, `userSource` | lowMach |
+| Moving mesh | ALE, piston, oscillating | mesh velocity kernel | - |
+| Particle tracking | Lagrangian, droplets | LPM callbacks | lpm |
+
+### Step 3: Create Case Directory
+
+Create the case directory under `examples/`:
+
+```bash
+mkdir -p examples/<caseName>
+```
+
+Use the name the user provides, or infer a descriptive snake_case name from the physics (e.g., `heated_channel`, `turbulent_pipe`, `lid_driven_cavity`).
+
+### Step 4: Generate Files
+
+Generate these files in order. Read reference files as needed:
+
+1. **`<caseName>.par`** — Read [PAR_REFERENCE.md](references/PAR_REFERENCE.md) for all valid keys
+2. **`<caseName>.udf`** — Read [UDF_PATTERNS.md](references/UDF_PATTERNS.md) for callback patterns
+3. **`<caseName>.oudf`** (if needed) — Read [BOUNDARY_CONDITIONS.md](references/BOUNDARY_CONDITIONS.md) for BC function signatures
+
+### Step 5: Validate
+
+Check the generated files for consistency:
+
+- [ ] Every boundary ID in `boundaryTypeMap` has a corresponding handler if `udfDirichlet`/`udfNeumann`/`udfRobin`
+- [ ] Scalar names in `[GENERAL] scalars = ...` match `[SCALAR name]` sections
+- [ ] `udfDirichlet` in `.oudf` handles all fields that use it (check with `isField()`)
+- [ ] Properties (viscosity, density) are consistent with stated Reynolds number
+- [ ] If RANS: scalars include `K` and `TAU`, and `RANSktau` plugin is initialized
+- [ ] If lowMach: `userDivergence` is registered and `lowMach::setup()` is called
+- [ ] `[CASEDATA]` parameters match what `UDF_Setup0` extracts
+
+## Gotchas
+
+- Boundary IDs in `boundaryTypeMap` are positional: first type = boundary ID 1, second = ID 2, etc.
+- `isField()` comparisons in `.oudf` are **case-insensitive** but must match the field name exactly (e.g., `"fluid velocity"`, `"scalar temperature"`, `"scalar00"`)
+- Scalar names from `.par` map to field names: `[SCALAR TEMPERATURE]` becomes field `"scalar temperature"` in `isField()`. For unnamed scalars, use `"scalar00"`, `"scalar01"`, etc.
+- `platform->par->extract()` keys are **case-insensitive**
+- OKL kernels in `#ifdef __okl__` blocks use `@kernel`, `@outer`, `@inner`, `@tile`, `@shared`, `@exclusive` decorators — NOT CUDA/HIP syntax
+- `dfloat` is the nekRS floating-point type (double or float depending on build) — always use it instead of `double`/`float` in UDF code
+- `dlong` is the nekRS integer type for global indices
+- Device memory uses `o_` prefix convention (e.g., `o_U` is velocity on GPU)
+- Field offset: velocity components are stored contiguously as `[ux | uy | uz]` each of size `fieldOffset`
+- The `usrwrk` array in `bcData` is a **read-only** pointer to a global workspace set from the UDF side
+- `UDF_Setup0` runs **before** the mesh and solvers exist — only `platform->par` and MPI are available
+- `UDF_Setup` runs **after** solvers are created — this is where you access `nrs`, `mesh`, register callbacks
+- For constant pressure-gradient driven flows, prefer `constFlowRate` in `[GENERAL]` over manual forcing
+- `regularization = hpfrt` requires `+nModes=<int>+scalingCoeff=<float>` — omitting either causes errors
+- Never include `ci.inc` or CI-related code in generated cases — that's for regression tests only
+
+## File Templates
+
+### Minimal `.par` Template
+
+```ini
+[GENERAL]
+polynomialOrder = 7
+numSteps = 1000
+dt = 1e-03
+timeStepper = tombo2
+checkpointInterval = 500
+
+[FLUID VELOCITY]
+boundaryTypeMap = <types matching mesh boundary IDs>
+residualTol = 1e-06
+viscosity = <value>
+density = 1.0
+
+[FLUID PRESSURE]
+residualTol = 1e-04
+```
+
+### Minimal `.udf` Template
+
+```cpp
+#include "nrs.hpp"
+#include "udf.hpp"
+
+#ifdef __okl__
+// OKL kernels here (boundary conditions, forcing, etc.)
+#endif
+
+void UDF_Setup0(MPI_Comm comm, setupAide &options)
+{
+  // Extract [CASEDATA] parameters
+  // platform->par->extract("casedata", "key", variable);
+}
+
+void UDF_Setup()
+{
+  // Register callbacks
+  // nrs->userSource = &myForcing;
+  // nrs->userProperties = &myProperties;
+}
+
+void UDF_ExecuteStep(double time, int tstep)
+{
+  // Per-timestep operations (diagnostics, I/O)
+}
+```
+
+### Minimal `.oudf` Template (when custom BCs are needed)
+
+```okl
+void udfDirichlet(bcData *bc)
+{
+  if (isField("fluid velocity")) {
+    bc->uxFluid = 0.0;
+    bc->uyFluid = 0.0;
+    bc->uzFluid = 0.0;
+  }
+}
+```

--- a/.claude/skills/udf-generator/references/BOUNDARY_CONDITIONS.md
+++ b/.claude/skills/udf-generator/references/BOUNDARY_CONDITIONS.md
@@ -1,0 +1,203 @@
+# nekRS Boundary Condition Reference
+
+## bcData Struct Fields
+
+Available inside `udfDirichlet`, `udfNeumann`, `udfRobin` functions:
+
+### Position and Time
+```
+bc->x, bc->y, bc->z     // Boundary node coordinates
+bc->time                 // Current simulation time
+```
+
+### Surface Geometry
+```
+bc->nx, bc->ny, bc->nz   // Unit outward normal
+bc->t1x, bc->t1y, bc->t1z // Tangent vector 1
+bc->t2x, bc->t2y, bc->t2z // Tangent vector 2
+```
+
+### Fluid Fields (set these in udfDirichlet)
+```
+bc->uxFluid, bc->uyFluid, bc->uzFluid  // Velocity Dirichlet values
+bc->pFluid                              // Pressure value
+bc->uxFluidInt, bc->uyFluidInt, bc->uzFluidInt  // Interior interpolated values
+```
+
+### Scalar Fields
+```
+bc->sScalar      // Scalar Dirichlet value (set in udfDirichlet)
+bc->fluxScalar   // Scalar normal flux (set in udfNeumann)
+bc->sScalarInt   // Interior interpolated scalar
+bc->sInfScalar   // Far-field scalar (Robin BC)
+bc->h            // Heat transfer coefficient (Robin BC)
+bc->diffCoeff    // Diffusion coefficient at boundary
+bc->transCoeff   // Transport coefficient at boundary
+bc->idScalar     // Scalar index
+```
+
+### Traction (Neumann for velocity)
+```
+bc->tr1, bc->tr2   // Tangential traction components
+```
+
+### Mesh Motion (Geometry)
+```
+bc->uxGeom, bc->uyGeom, bc->uzGeom  // Mesh velocity Dirichlet values
+```
+
+### Metadata
+```
+bc->id           // Boundary tag ID (from mesh)
+bc->idxVol       // Volume node index
+bc->fieldOffset  // Field array offset
+bc->usrwrk       // Read-only pointer to user workspace array
+```
+
+### Field Identification
+```cpp
+isField("fluid velocity")      // Check if current field is velocity
+isField("fluid pressure")      // Check if current field is pressure
+isField("scalar temperature")  // Named scalar
+isField("scalar00")            // Scalar by index
+isField("geom")                // Mesh motion field
+```
+
+---
+
+## Function Templates
+
+### udfDirichlet — Set Dirichlet Values
+
+```okl
+void udfDirichlet(bcData *bc)
+{
+  // Velocity inlet: parabolic profile
+  if (isField("fluid velocity")) {
+    if (bc->id == 1) {  // inlet boundary
+      const dfloat y = bc->y;
+      const dfloat H = 1.0;
+      bc->uxFluid = 4.0 * y * (H - y) / (H * H);
+      bc->uyFluid = 0.0;
+      bc->uzFluid = 0.0;
+    }
+  }
+
+  // Temperature: fixed wall temperature
+  if (isField("scalar temperature")) {
+    if (bc->id == 1) {
+      bc->sScalar = 1.0;  // hot wall
+    } else if (bc->id == 2) {
+      bc->sScalar = 0.0;  // cold wall
+    }
+  }
+}
+```
+
+### udfNeumann — Set Normal Flux
+
+```okl
+void udfNeumann(bcData *bc)
+{
+  if (isField("scalar temperature")) {
+    // Constant heat flux
+    bc->fluxScalar = 1.0;
+  }
+}
+```
+
+### udfRobin — Set Convective/Mixed BC
+
+```okl
+void udfRobin(bcData *bc)
+{
+  if (isField("scalar temperature")) {
+    // h*(T - T_inf) + k*dT/dn = 0
+    bc->h = 10.0;            // heat transfer coefficient
+    bc->sInfScalar = 300.0;  // ambient temperature
+    // bc->diffCoeff is set automatically from .par
+  }
+}
+```
+
+---
+
+## Common BC Recipes
+
+### Parabolic Inlet (2D channel)
+```okl
+if (isField("fluid velocity")) {
+  const dfloat y = bc->y;
+  bc->uxFluid = 6.0 * y * (1.0 - y);  // normalized for unit height
+  bc->uyFluid = 0.0;
+  bc->uzFluid = 0.0;
+}
+```
+
+### Poiseuille Pipe Inlet
+```okl
+if (isField("fluid velocity")) {
+  const dfloat r2 = bc->y * bc->y + bc->z * bc->z;
+  const dfloat R = 0.5;
+  bc->uxFluid = 2.0 * U_bulk * (1.0 - r2 / (R * R));
+  bc->uyFluid = 0.0;
+  bc->uzFluid = 0.0;
+}
+```
+
+### Time-Varying Inlet
+```okl
+if (isField("fluid velocity")) {
+  const dfloat amp = 0.1;
+  const dfloat freq = 2.0;
+  bc->uxFluid = 1.0 + amp * sin(freq * bc->time);
+  bc->uyFluid = 0.0;
+  bc->uzFluid = 0.0;
+}
+```
+
+### Temperature Ramp
+```okl
+if (isField("scalar temperature")) {
+  const dfloat t_ramp = 1.0;  // ramp duration
+  const dfloat T_hot = 1.0;
+  const dfloat factor = tanh(bc->time / t_ramp);
+  bc->sScalar = T_hot * factor;
+}
+```
+
+### Rotating Wall
+```okl
+if (isField("fluid velocity")) {
+  const dfloat omega = 1.0;
+  bc->uxFluid = -omega * bc->y;
+  bc->uyFluid =  omega * bc->x;
+  bc->uzFluid = 0.0;
+}
+```
+
+### Using usrwrk for Computed BCs
+```okl
+// In .oudf - read data set from UDF side
+void udfDirichlet(bcData *bc)
+{
+  if (isField("fluid velocity")) {
+    const int idxU = 0;  // usrwrk slot indices
+    const int idxV = 1;
+    const int idxW = 2;
+    bc->uxFluid = bc->usrwrk[bc->idxVol + idxU * bc->fieldOffset];
+    bc->uyFluid = bc->usrwrk[bc->idxVol + idxV * bc->fieldOffset];
+    bc->uzFluid = bc->usrwrk[bc->idxVol + idxW * bc->fieldOffset];
+  }
+}
+```
+
+---
+
+## Boundary Type Mapping Rules
+
+1. Types in `boundaryTypeMap` are **comma-separated** and **positional**: first = boundary ID 1, second = boundary ID 2, etc.
+2. The number of entries must match the number of unique boundary IDs in the `.re2` mesh.
+3. Compound types use `/`: `zeroDirichletN/zeroNeumann` means zero normal velocity + zero tangential gradient.
+4. Every `udfDirichlet` / `udfNeumann` / `udfRobin` boundary must have a corresponding handler in the `.oudf` or `__okl__` section.
+5. Periodic boundaries are handled by the mesh (not in `boundaryTypeMap`) — they don't appear in the map.

--- a/.claude/skills/udf-generator/references/PAR_REFERENCE.md
+++ b/.claude/skills/udf-generator/references/PAR_REFERENCE.md
@@ -1,0 +1,145 @@
+# nekRS .par File Reference
+
+Complete reference for all valid `.par` file sections and keys.
+
+## [GENERAL] Section
+
+| Key | Values | Default | Notes |
+|-----|--------|---------|-------|
+| `polynomialOrder` | int | **required** | Spectral element degree (typically 5-9) |
+| `verbose` | true/false | false | |
+| `startFrom` | string | - | Restart file. Modifiers: `+time=<f>`, `+x`, `+u`, `+s`, `+int` |
+| `timeStepper` | bdf1/tombo1, bdf2/tombo2, bdf3/tombo3 | tombo2 | |
+| `stopAt` | numSteps, endTime, elapsedTime | numSteps | |
+| `numSteps` | int | - | |
+| `endTime` | float | - | |
+| `dt` | float or expr | - | Modifiers: `+targetCFL=<f>`, `+max=<f>`, `+initial=<f>` |
+| `advectionSubCyclingSteps` | int, auto | 0 | OIFS subcycling |
+| `checkpointControl` | steps, simulationTime | steps | |
+| `checkpointInterval` | int/float | 0 | -1 to disable |
+| `checkpointPrecision` | 32, 64 | 32 | |
+| `dealiasing` | true/false | true | |
+| `cubaturePolynomialOrder` | int | 3/2*(P+1)-1 | |
+| `constFlowRate` | expression | - | e.g., `meanVelocity=1.0+direction=X` |
+| `scalars` | name1, name2, ... | - | Scalar field names |
+| `regularization` | none, hpfrt, gjp, avm | - | See regularization section |
+| `userSections` | string, ... | - | Custom .par sections to parse |
+| `udf` / `oudf` / `usr` | string | - | Override default file names |
+| `redirectOutputTo` | string | - | Log file name |
+
+## [OCCA] Section
+
+| Key | Values | Default |
+|-----|--------|---------|
+| `backend` | SERIAL, CUDA, HIP, DPCPP | from nekrs.conf |
+| `deviceNumber` | int, LOCAL-RANK | 0 |
+
+## [MESH] Section
+
+| Key | Values | Default |
+|-----|--------|---------|
+| `file` | string | `<caseName>.re2` |
+| `partitioner` | rcb, rcb+rsb | rcb+rsb |
+| `connectivityTol` | float | 0.2 |
+| `boundaryIDMap` | int, int, ... | - |
+| `hRefine` | int, int, ... | - |
+
+## [PROBLEMTYPE] Section
+
+| Key | Values | Default |
+|-----|--------|---------|
+| `equation` | stokes, navierStokes | navierStokes |
+| `stressFormulation` | true/false | false |
+
+Modifier: `+variableViscosity` on equation enables stress formulation.
+
+## [FLUID VELOCITY] Section
+
+| Key | Values | Default |
+|-----|--------|---------|
+| `boundaryTypeMap` | BC types (comma-separated) | **required** |
+| `density` / `rho` | float or expr | 1.0 |
+| `viscosity` / `mu` | float or expr | 1.0 |
+| `solver` | CG, CG+BLOCK, GMRES, ... | CG+BLOCK |
+| `preconditioner` | jacobi, multigrid | jacobi |
+| `residualTol` | float | 1e-4 |
+| `initialGuess` | extrapolation, projection | extrapolation |
+| `regularization` | hpfrt, gjp, none | - |
+
+## [FLUID PRESSURE] Section
+
+| Key | Values | Default |
+|-----|--------|---------|
+| `solver` | GMRES+FLEXIBLE+NVECTOR=15 | GMRES+FLEXIBLE |
+| `preconditioner` | multigrid | multigrid |
+| `residualTol` | float | 1e-4 |
+| `initialGuess` | projection, projectionAconj | projectionAconj |
+| `boundaryTypeMap` | BC types | - |
+
+## [SCALAR name] Section
+
+| Key | Values | Default |
+|-----|--------|---------|
+| `boundaryTypeMap` | BC types | - |
+| `diffusionCoeff` / `conductivity` | float or expr | - |
+| `transportCoeff` / `rhoCp` | float or expr | - |
+| `diffusionCoeffSolid` | float or expr | - |
+| `transportCoeffSolid` | float or expr | - |
+| `mesh` | fluid, fluid+solid | fluid |
+| `solver` | CG, GMRES, CVODE, NONE | CG |
+| `preconditioner` | jacobi, multigrid | jacobi |
+| `residualTol` | float | 1e-4 |
+| `checkpointing` | true/false | true |
+
+## [GEOM] Section (Moving Mesh)
+
+| Key | Values | Default |
+|-----|--------|---------|
+| `solver` | CG+BLOCK, NONE, USER | CG+BLOCK |
+| `boundaryTypeMap` | BC types | - |
+| `preconditioner` | jacobi, multigrid | jacobi |
+
+## Regularization Options
+
+Format: `regularization = method+param1=val1+param2=val2`
+
+- **hpfrt**: `+nModes=<int>+scalingCoeff=<float>` (both required)
+- **gjp**: `+scalingCoeff=<float>`
+- **avm**: `+c0+scalingCoeff=<float>` (scalars only)
+
+## Solver Modifiers
+
+- CG: `+combined`, `+block`, `+flexible`, `+maxiter=<int>`
+- GMRES: `+flexible`, `+nVector=<int>`, `+maxiter=<int>`, `+ir`
+
+## Preconditioner Modifiers
+
+- multigrid: `+multiplicative`/`+additive`, `+SEMFEM`
+- smootherType: ASM, RAS, `+Chebyshev`, `+FourthOptChebyshev`, `+degree=<int>`
+- coarseSolver: smoother, jpcg, boomerAMG (`+cpu`/`+device`, `+overlap`)
+
+## Boundary Condition Types
+
+### Velocity BCs
+| Type | Aliases | Description |
+|------|---------|-------------|
+| `zeroDirichlet` | w, wall, inlet | No-slip wall / zero velocity |
+| `udfDirichlet` | v | User-defined velocity (calls `udfDirichlet`) |
+| `zeroNeumann` | o, O, outlet, outflow | Zero-gradient outflow |
+| `zeroDirichletN/zeroNeumann` | slip, sym | Free-slip / symmetry |
+| `zeroDirichletX/zeroNeumann` | slipx, symx | Symmetry in X |
+| `zeroDirichletY/zeroNeumann` | slipy, symy | Symmetry in Y |
+| `zeroDirichletZ/zeroNeumann` | slipz, symz | Symmetry in Z |
+| `zeroDirichletN/udfNeumann` | traction, shl | User traction BC |
+| `interpolation` | int | NekNek interpolated BC |
+| `none` | - | Internal / periodic |
+
+### Scalar BCs
+| Type | Description |
+|------|-------------|
+| `udfDirichlet` | User-defined value (calls `udfDirichlet`) |
+| `udfNeumann` | User-defined flux (calls `udfNeumann`) |
+| `udfRobin` / `convective` | Mixed BC (calls `udfRobin`) |
+| `zeroNeumann` / `insulated` | Zero flux (adiabatic) |
+| `interpolation` | NekNek interpolated |
+| `none` | Internal / periodic |

--- a/.claude/skills/udf-generator/references/UDF_PATTERNS.md
+++ b/.claude/skills/udf-generator/references/UDF_PATTERNS.md
@@ -7,11 +7,11 @@
 #include "udf.hpp"
 ```
 
-Additional headers by feature:
-- `#include "plugins/tavg.hpp"` — time averaging
-- `#include "plugins/RANSktau.hpp"` — k-tau RANS
-- `#include "plugins/lowMach.hpp"` — low-Mach
-- `#include "plugins/lpm.hpp"` — Lagrangian particles
+Additional headers by feature (use short form, matching existing examples):
+- `#include "tavg.hpp"` — time averaging
+- `#include "RANSktau.hpp"` — k-tau RANS
+- `#include "lowMach.hpp"` — low-Mach
+- `#include "lpm.hpp"` — Lagrangian particles
 
 ## Core Callback Signatures
 
@@ -204,12 +204,28 @@ void userSource(double time)
 
 ## Pattern: RANS k-tau SST
 
-Requires scalars `K` and `TAU` in `.par`.
+Requires scalars `K` and `TAU` in `.par`, and `equation = navierStokes+variableViscosity`
+in `[PROBLEMTYPE]`.
+
+### Minimal RANS (no temperature)
 
 ```cpp
-#include "nrs.hpp"
-#include "udf.hpp"
-#include "plugins/RANSktau.hpp"
+#include "RANSktau.hpp"
+
+#ifdef __okl__
+
+void udfDirichlet(bcData *bc)
+{
+  // Wall BC for k and tau
+  if (isField("scalar k")) {
+    bc->sScalar = 0.0;
+  }
+  if (isField("scalar tau")) {
+    bc->sScalar = 1e-12;
+  }
+}
+
+#endif
 
 void userq(double time)
 {
@@ -218,32 +234,171 @@ void userq(double time)
 
 void uservp(double time)
 {
-  auto mesh = nrs->meshV;
-
-  // Update RANS eddy viscosity
   RANSktau::updateProperties();
+}
 
-  // If there's a temperature scalar, add turbulent diffusion
-  dfloat conduct;
-  platform->options.getArgs("SCALAR00 DIFFUSIVITY", conduct);
-  const dfloat Pr_t = 0.85;
-  scalarScaledAdd(mesh->Nlocal, conduct, 1.0 / Pr_t,
-                  RANSktau::o_mue_t(),
-                  nrs->scalar->o_diffusionCoeff("temperature"));
+void UDF_Setup0(MPI_Comm comm, setupAide &options) {}
+
+void UDF_Setup()
+{
+  nrs->userProperties = &uservp;
+  nrs->userSource = &userq;
+
+  // Set IC if not restarting
+  if (platform->options.getArgs("RESTART FILE NAME").empty()) {
+    auto mesh = nrs->meshV;
+    std::vector<dfloat> U(nrs->fluid->fieldOffsetSum, 0.0);
+    std::vector<dfloat> k(mesh->Nlocal, 0.01);
+    std::vector<dfloat> tau(mesh->Nlocal, 0.1);
+    for (int n = 0; n < mesh->Nlocal; n++) {
+      U[n + 0 * nrs->fieldOffset] = 1.0;
+    }
+    nrs->fluid->o_U.copyFrom(U.data(), U.size());
+    nrs->scalar->o_solution("k").copyFrom(k.data(), k.size());
+    nrs->scalar->o_solution("tau").copyFrom(tau.data(), tau.size());
+  }
+
+  RANSktau::setup(nrs->scalar->nameToIndex.find("k")->second);
+}
+
+void UDF_ExecuteStep(double time, int tstep) {}
+```
+
+### RANS with Inlet Turbulence (inflow/outflow cases)
+
+For cases with inflow BCs, pass inlet k/tau as compile-time constants:
+
+```cpp
+#include "RANSktau.hpp"
+
+static dfloat P_U_INLET, P_K_INLET, P_TAU_INLET;
+
+#ifdef __okl__
+
+void udfDirichlet(bcData *bc)
+{
+  if (isField("fluid velocity")) {
+    if (bc->id == 1) {  // inlet
+      bc->uxFluid = p_U_INLET;
+      bc->uyFluid = 0.0;
+      bc->uzFluid = 0.0;
+    }
+  }
+  if (isField("scalar k")) {
+    if (bc->id == 1) {
+      bc->sScalar = p_K_INLET;
+    } else if (bc->id == 3) {  // wall
+      bc->sScalar = 0.0;
+    }
+  }
+  if (isField("scalar tau")) {
+    if (bc->id == 1) {
+      bc->sScalar = p_TAU_INLET;
+    } else if (bc->id == 3) {  // wall
+      bc->sScalar = 1e-12;
+    }
+  }
+}
+
+#endif
+
+void userq(double time)
+{
+  RANSktau::updateSourceTerms();
+}
+
+void uservp(double time)
+{
+  RANSktau::updateProperties();
+}
+
+void UDF_LoadKernels(deviceKernelProperties &kernelInfo)
+{
+  kernelInfo.define("p_U_INLET") = P_U_INLET;
+  kernelInfo.define("p_K_INLET") = P_K_INLET;
+  kernelInfo.define("p_TAU_INLET") = P_TAU_INLET;
 }
 
 void UDF_Setup0(MPI_Comm comm, setupAide &options)
 {
-  // RANSktau requires stress formulation
-  options.setArgs("PROBLEMTYPE EQUATION", std::string("navierStokes+variableViscosity"));
+  dfloat TI;
+  platform->par->extract("casedata", "u_inlet", P_U_INLET);
+  platform->par->extract("casedata", "ti", TI);
+
+  // k = 1.5 * (U * TI)^2
+  P_K_INLET = 1.5 * (P_U_INLET * TI) * (P_U_INLET * TI);
+
+  // tau = 1/omega, omega = k^0.5 / (Cmu^0.25 * l_t), l_t = 0.07 * D
+  dfloat D;
+  platform->par->extract("casedata", "diameter", D);
+  const dfloat l_t = 0.07 * D;
+  const dfloat Cmu = 0.09;
+  const dfloat omega = sqrt(P_K_INLET) / (pow(Cmu, 0.25) * l_t);
+  P_TAU_INLET = 1.0 / omega;
 }
 
 void UDF_Setup()
 {
   nrs->userProperties = &uservp;
   nrs->userSource = &userq;
-  RANSktau::setup(nrs->scalar->nameToIndex["k"]);
+
+  if (platform->options.getArgs("RESTART FILE NAME").empty()) {
+    auto mesh = nrs->meshV;
+    std::vector<dfloat> U(nrs->fluid->fieldOffsetSum, 0.0);
+    std::vector<dfloat> k(mesh->Nlocal, P_K_INLET);
+    std::vector<dfloat> tau(mesh->Nlocal, P_TAU_INLET);
+    for (int n = 0; n < mesh->Nlocal; n++) {
+      U[n + 0 * nrs->fieldOffset] = P_U_INLET;
+    }
+    nrs->fluid->o_U.copyFrom(U.data(), U.size());
+    nrs->scalar->o_solution("k").copyFrom(k.data(), k.size());
+    nrs->scalar->o_solution("tau").copyFrom(tau.data(), tau.size());
+  }
+
+  RANSktau::setup(nrs->scalar->nameToIndex.find("k")->second);
 }
+
+void UDF_ExecuteStep(double time, int tstep) {}
+```
+
+### RANS with Temperature (turbulent heat transfer)
+
+Add turbulent diffusion to the temperature scalar's diffusion coefficient:
+
+```cpp
+// In uservp, AFTER RANSktau::updateProperties():
+dfloat conduct;
+platform->options.getArgs("SCALAR00 DIFFUSIVITY", conduct);
+const dfloat Pr_t = 0.85;
+// Need a scalarScaledAdd kernel for this:
+// Y[n] = conduct + (1/Pr_t) * mue_t[n]
+scalarScaledAdd(mesh->Nlocal, conduct, 1.0 / Pr_t,
+                RANSktau::o_mue_t(),
+                nrs->scalar->o_diffusionCoeff("temperature"));
+```
+
+Only include the `scalarScaledAdd` OKL kernel when the case has a temperature scalar.
+
+### RANS .par template
+
+```ini
+[GENERAL]
+polynomialOrder = 7
+dt = targetCFL=0.5+initial=1e-3
+timeStepper = tombo2
+scalars = k, tau
+
+[PROBLEMTYPE]
+equation = navierStokes+variableViscosity
+
+[SCALAR K]
+boundaryTypeMap = udfDirichlet, zeroNeumann, udfDirichlet
+residualTol = 1e-08
+
+[SCALAR TAU]
+boundaryTypeMap = udfDirichlet, zeroNeumann, udfDirichlet
+residualTol = 1e-08
+```
 ```
 
 ---
@@ -251,7 +406,7 @@ void UDF_Setup()
 ## Pattern: Time Averaging (tavg)
 
 ```cpp
-#include "plugins/tavg.hpp"
+#include "tavg.hpp"
 
 static std::unique_ptr<tavg> avg;
 
@@ -291,7 +446,7 @@ void UDF_ExecuteStep(double time, int tstep)
 ## Pattern: Low-Mach Variable Density
 
 ```cpp
-#include "plugins/lowMach.hpp"
+#include "lowMach.hpp"
 
 static dfloat P_GAMMA;
 static deviceMemory<dfloat> o_beta, o_kappa;
@@ -320,23 +475,23 @@ void UDF_Setup()
 
 ## Pattern: Custom Initial Conditions
 
-Set IC in `UDF_Setup()` after solvers are initialized:
+Set IC in `UDF_Setup()` after solvers are initialized. Use `fieldOffsetSum` for velocity:
 
 ```cpp
 void UDF_Setup()
 {
   auto mesh = nrs->meshV;
   auto [x, y, z] = mesh->xyzHost();
-  dlong Nlocal = mesh->Nlocal;
-  dlong fieldOffset = nrs->fieldOffset;
 
-  std::vector<dfloat> U(3 * fieldOffset, 0.0);
-  for (dlong n = 0; n < Nlocal; n++) {
-    U[n + 0 * fieldOffset] = 1.0;  // ux
-    U[n + 1 * fieldOffset] = 0.0;  // uy
-    U[n + 2 * fieldOffset] = 0.0;  // uz
+  if (platform->options.getArgs("RESTART FILE NAME").empty()) {
+    std::vector<dfloat> U(nrs->fluid->fieldOffsetSum, 0.0);
+    for (dlong n = 0; n < mesh->Nlocal; n++) {
+      U[n + 0 * nrs->fieldOffset] = 1.0;  // ux
+      U[n + 1 * nrs->fieldOffset] = 0.0;  // uy
+      U[n + 2 * nrs->fieldOffset] = 0.0;  // uz
+    }
+    nrs->fluid->o_U.copyFrom(U.data(), U.size());
   }
-  nrs->fluid->o_U.copyFrom(U.data());
 }
 ```
 

--- a/.claude/skills/udf-generator/references/UDF_PATTERNS.md
+++ b/.claude/skills/udf-generator/references/UDF_PATTERNS.md
@@ -1,0 +1,354 @@
+# nekRS UDF Patterns by Physics Type
+
+## Required Headers
+
+```cpp
+#include "nrs.hpp"
+#include "udf.hpp"
+```
+
+Additional headers by feature:
+- `#include "plugins/tavg.hpp"` — time averaging
+- `#include "plugins/RANSktau.hpp"` — k-tau RANS
+- `#include "plugins/lowMach.hpp"` — low-Mach
+- `#include "plugins/lpm.hpp"` — Lagrangian particles
+
+## Core Callback Signatures
+
+```cpp
+void UDF_Setup0(MPI_Comm comm, setupAide &options);
+void UDF_Setup();
+void UDF_LoadKernels(deviceKernelProperties& kernelInfo);
+void UDF_ExecuteStep(double time, int tstep);
+```
+
+## Available User Callbacks (registered in UDF_Setup)
+
+```cpp
+nrs->userSource = &myForcing;           // Body forces
+nrs->userProperties = &myProperties;    // Variable rho, mu
+nrs->userDivergence = &myDivergence;    // Custom divergence (lowMach)
+nrs->userConvergenceCheck = &myCheck;   // Outer iteration control
+nrs->fluid->userImplicitLinearTerm = &myImplicit;  // Implicit forcing
+```
+
+## Key Data Access
+
+```cpp
+auto mesh = nrs->meshV;
+dlong fieldOffset = nrs->fieldOffset;
+dlong Nlocal = mesh->Nlocal;
+
+// Velocity (device)
+auto o_U = nrs->fluid->o_U;  // [ux | uy | uz], each fieldOffset long
+
+// Scalars
+auto& o_S = nrs->scalar->o_solution("temperature");
+
+// Properties
+auto& o_mue = nrs->fluid->o_mue;   // viscosity
+auto& o_rho = nrs->fluid->o_rho;   // density
+auto& o_diff = nrs->scalar->o_diffusionCoeff("temperature");
+
+// Mesh coordinates (host)
+auto [x, y, z] = mesh->xyzHost();
+
+// Parameter extraction
+dfloat val;
+platform->par->extract("casedata", "key", val);
+platform->options.getArgs("FLUID VISCOSITY", val);
+```
+
+## Linear Algebra Operations
+
+```cpp
+platform->linAlg->fill(N, value, o_array);
+platform->linAlg->add(N, value, o_array);
+platform->linAlg->scale(N, factor, o_array);
+platform->linAlg->axpby(N, a, o_x, b, o_y);  // y = a*x + b*y
+platform->linAlg->axpbyz(N, a, o_x, b, o_y, o_z);  // z = a*x + b*y
+dfloat dot = platform->linAlg->innerProd(N, o_x, o_y, comm);
+dfloat vmin = platform->linAlg->min(N, o_x, comm);
+dfloat vmax = platform->linAlg->max(N, o_x, comm);
+```
+
+---
+
+## Pattern: Laminar Flow
+
+Minimal UDF. Boundary conditions handled in `.oudf` or via `zeroDirichlet`/`zeroNeumann`.
+
+```cpp
+#include "nrs.hpp"
+#include "udf.hpp"
+
+void UDF_Setup0(MPI_Comm comm, setupAide &options) {}
+void UDF_Setup() {}
+void UDF_ExecuteStep(double time, int tstep) {}
+```
+
+---
+
+## Pattern: Constant Pressure-Gradient Driven Flow
+
+For channel/pipe flows. Prefer `constFlowRate` in `.par` when possible.
+
+**Manual forcing approach:**
+
+```cpp
+static dfloat P_DPDX;
+
+#ifdef __okl__
+@kernel void constantForcing(const dlong N,
+                             const dlong offset,
+                             const dfloat dpdx,
+                             @restrict dfloat *EXT)
+{
+  for (dlong n = 0; n < N; ++n; @tile(p_blockSize, @outer, @inner)) {
+    EXT[n + 0 * offset] += dpdx;  // x-direction force
+  }
+}
+#endif
+
+void userSource(double time)
+{
+  auto mesh = nrs->meshV;
+  constantForcing(mesh->Nlocal, nrs->fieldOffset, P_DPDX, nrs->fluid->o_EXT);
+}
+
+void UDF_Setup0(MPI_Comm comm, setupAide &options)
+{
+  platform->par->extract("casedata", "p_dpdx", P_DPDX);
+}
+
+void UDF_Setup()
+{
+  nrs->userSource = &userSource;
+}
+```
+
+---
+
+## Pattern: Temperature-Dependent Properties
+
+```cpp
+static dfloat P_BETA;  // thermal expansion coefficient
+
+#ifdef __okl__
+@kernel void setProperties(const dlong N,
+                           const dfloat rho0,
+                           const dfloat mu0,
+                           const dfloat beta,
+                           @restrict const dfloat *TEMP,
+                           @restrict dfloat *RHO,
+                           @restrict dfloat *MUE)
+{
+  for (dlong n = 0; n < N; ++n; @tile(p_blockSize, @outer, @inner)) {
+    RHO[n] = rho0 * (1.0 - beta * TEMP[n]);
+    MUE[n] = mu0;
+  }
+}
+#endif
+
+void uservp(double time)
+{
+  auto mesh = nrs->meshV;
+  dfloat rho0, mu0;
+  platform->options.getArgs("FLUID DENSITY", rho0);
+  platform->options.getArgs("FLUID VISCOSITY", mu0);
+
+  setProperties(mesh->Nlocal, rho0, mu0, P_BETA,
+                nrs->scalar->o_solution("temperature"),
+                nrs->fluid->o_rho, nrs->fluid->o_mue);
+}
+
+void UDF_Setup()
+{
+  nrs->userProperties = &uservp;
+}
+```
+
+---
+
+## Pattern: Buoyancy (Boussinesq Approximation)
+
+```cpp
+static dfloat P_BETA, P_T_REF;
+static int gravityDir = 1;  // y-direction
+
+#ifdef __okl__
+@kernel void buoyancyForcing(const dlong N,
+                             const dlong offset,
+                             const dfloat beta,
+                             const dfloat T_ref,
+                             const int gDir,
+                             @restrict const dfloat *TEMP,
+                             @restrict dfloat *EXT)
+{
+  for (dlong n = 0; n < N; ++n; @tile(p_blockSize, @outer, @inner)) {
+    const dfloat dT = TEMP[n] - T_ref;
+    EXT[n + gDir * offset] += -beta * dT;  // -beta*(T-Tref)*g_hat
+  }
+}
+#endif
+
+void userSource(double time)
+{
+  auto mesh = nrs->meshV;
+  buoyancyForcing(mesh->Nlocal, nrs->fieldOffset, P_BETA, P_T_REF, gravityDir,
+                  nrs->scalar->o_solution("temperature"), nrs->fluid->o_EXT);
+}
+```
+
+---
+
+## Pattern: RANS k-tau SST
+
+Requires scalars `K` and `TAU` in `.par`.
+
+```cpp
+#include "nrs.hpp"
+#include "udf.hpp"
+#include "plugins/RANSktau.hpp"
+
+void userq(double time)
+{
+  RANSktau::updateSourceTerms();
+}
+
+void uservp(double time)
+{
+  auto mesh = nrs->meshV;
+
+  // Update RANS eddy viscosity
+  RANSktau::updateProperties();
+
+  // If there's a temperature scalar, add turbulent diffusion
+  dfloat conduct;
+  platform->options.getArgs("SCALAR00 DIFFUSIVITY", conduct);
+  const dfloat Pr_t = 0.85;
+  scalarScaledAdd(mesh->Nlocal, conduct, 1.0 / Pr_t,
+                  RANSktau::o_mue_t(),
+                  nrs->scalar->o_diffusionCoeff("temperature"));
+}
+
+void UDF_Setup0(MPI_Comm comm, setupAide &options)
+{
+  // RANSktau requires stress formulation
+  options.setArgs("PROBLEMTYPE EQUATION", std::string("navierStokes+variableViscosity"));
+}
+
+void UDF_Setup()
+{
+  nrs->userProperties = &uservp;
+  nrs->userSource = &userq;
+  RANSktau::setup(nrs->scalar->nameToIndex["k"]);
+}
+```
+
+---
+
+## Pattern: Time Averaging (tavg)
+
+```cpp
+#include "plugins/tavg.hpp"
+
+static std::unique_ptr<tavg> avg;
+
+void UDF_Setup()
+{
+  auto mesh = nrs->meshV;
+  dlong fieldOffset = nrs->fieldOffset;
+
+  std::vector<tavg::field> tavgFields;
+  deviceMemory<dfloat> o_ux(nrs->fluid->o_solution("x"));
+  deviceMemory<dfloat> o_uy(nrs->fluid->o_solution("y"));
+  deviceMemory<dfloat> o_uz(nrs->fluid->o_solution("z"));
+
+  // Mean fields
+  tavgFields.push_back({"ux", std::vector{o_ux}});
+  tavgFields.push_back({"uy", std::vector{o_uy}});
+  tavgFields.push_back({"uz", std::vector{o_uz}});
+
+  // Reynolds stresses
+  tavgFields.push_back({"uxux", std::vector{o_ux, o_ux}});
+  tavgFields.push_back({"uyuy", std::vector{o_uy, o_uy}});
+  tavgFields.push_back({"uzuz", std::vector{o_uz, o_uz}});
+  tavgFields.push_back({"uxuy", std::vector{o_ux, o_uy}});
+
+  avg = std::make_unique<tavg>(fieldOffset, tavgFields);
+}
+
+void UDF_ExecuteStep(double time, int tstep)
+{
+  if (nrs->timeStepConverged) avg->run(time);
+  if (nrs->checkpointStep) avg->writeToFile(nrs->meshV);
+}
+```
+
+---
+
+## Pattern: Low-Mach Variable Density
+
+```cpp
+#include "plugins/lowMach.hpp"
+
+static dfloat P_GAMMA;
+static deviceMemory<dfloat> o_beta, o_kappa;
+
+void qtl(double time)
+{
+  lowMach::qThermalSingleComponent(time);
+}
+
+void uservp(double time)
+{
+  // Update density from temperature: rho = p0 / (R * T)
+  // Fill o_beta and o_kappa based on temperature field
+}
+
+void UDF_Setup()
+{
+  dfloat alphaRef = (P_GAMMA - 1.0) / P_GAMMA;
+  lowMach::setup(alphaRef, o_beta, o_kappa);
+  nrs->userDivergence = &qtl;
+  nrs->userProperties = &uservp;
+}
+```
+
+---
+
+## Pattern: Custom Initial Conditions
+
+Set IC in `UDF_Setup()` after solvers are initialized:
+
+```cpp
+void UDF_Setup()
+{
+  auto mesh = nrs->meshV;
+  auto [x, y, z] = mesh->xyzHost();
+  dlong Nlocal = mesh->Nlocal;
+  dlong fieldOffset = nrs->fieldOffset;
+
+  std::vector<dfloat> U(3 * fieldOffset, 0.0);
+  for (dlong n = 0; n < Nlocal; n++) {
+    U[n + 0 * fieldOffset] = 1.0;  // ux
+    U[n + 1 * fieldOffset] = 0.0;  // uy
+    U[n + 2 * fieldOffset] = 0.0;  // uz
+  }
+  nrs->fluid->o_U.copyFrom(U.data());
+}
+```
+
+---
+
+## Pattern: Checkpoint Custom Fields
+
+```cpp
+void UDF_Setup()
+{
+  // Add Q-criterion as checkpoint field
+  deviceMemory<dfloat> o_Qcriterion(nrs->fieldOffset);
+  nrs->addUserCheckpointField("Q", o_Qcriterion);
+}
+```


### PR DESCRIPTION
## Summary

Adds an [Agent Skill](https://agentskills.io) that generates nekRS simulation case files (`.par`, `.udf`, `.oudf`) from natural language physics descriptions. Users describe their simulation setup (Reynolds number, boundary conditions, turbulence model, fluid properties, etc.) and the skill produces ready-to-run case files following established codebase patterns.

This is a first version of this skill and it can improve based on feedbacks and edge cases.

### What's included

```
.claude/skills/udf-generator/
├── SKILL.md                           # Workflow, gotchas, templates
└── references/
    ├── PAR_REFERENCE.md               # Complete .par file keys and valid values
    ├── UDF_PATTERNS.md                # UDF callback patterns by physics type
    └── BOUNDARY_CONDITIONS.md         # bcData struct, BC function signatures
```

### Supported physics categories

- Laminar / Stokes flow
- Turbulent flow (DNS/LES with regularization)
- RANS k-tau SST (with inlet turbulence, optional temperature)
- Heat transfer (constant and variable properties, conjugate HT)
- Low-Mach variable density
- Moving mesh (ALE)
- Lagrangian particle tracking

### How it works

1. Extracts flow conditions, boundary types, and models from the user's prompt
2. Asks clarifying questions for missing critical information
3. Generates `.par`, `.udf`, and `.oudf` files under `examples/<caseName>/`
4. Validates cross-file consistency (boundary maps, scalar names, field handlers)

All generated code follows patterns from existing examples (`periodicHill`, `ethier`, `turbPipePeriodic`, etc.) and respects project conventions (include paths, IC sizing, compile-time constants via `kernelInfo.define()`).